### PR TITLE
Issue #35 - add a warning when creating a blank template

### DIFF
--- a/src/main/java/ca/corbett/snotes/ui/template/TemplateBuilderDialog.java
+++ b/src/main/java/ca/corbett/snotes/ui/template/TemplateBuilderDialog.java
@@ -42,6 +42,7 @@ public class TemplateBuilderDialog extends JDialog {
     private ComboField<Template.Context> contextField;
     private ShortTextField tagField;
     private MessageUtil messageUtil;
+    private boolean blankWarningIssued;
 
     public TemplateBuilderDialog(Window owner) {
         this(owner, null);
@@ -59,6 +60,7 @@ public class TemplateBuilderDialog extends JDialog {
         initKeyBindings();
         initComponents();
         wasOkayed = false;
+        blankWarningIssued = false;
     }
 
     /**
@@ -103,6 +105,21 @@ public class TemplateBuilderDialog extends JDialog {
             if (!formPanel.isFormValid()) {
                 return; // dialog stays open until form is valid or user cancels
             }
+
+            // Check for "blank" templates:
+            if (dateOptionField.getSelectedIndex() == 0 && tagField.getText().isBlank()) {
+                // There's nothing technically wrong with this configuration, so let's not
+                // treat it as a hard validation failure. But, it's at least worth a warning:
+                if (!blankWarningIssued) {
+                    blankWarningIssued = true; // only warn once for this
+                    if (getMessageUtil().askYesNo("Confirm",
+                                                  "Are you sure you wish to create a blank template?"
+                                                      + "\nAll notes created from this Template will be empty.") == MessageUtil.NO) {
+                        return;
+                    }
+                }
+            }
+
             wasOkayed = true;
         }
 

--- a/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
@@ -2,6 +2,7 @@ Snotes Release Notes
 Author: Steve Corbett
 
 Version 2.0 [TODO] rewrite
+  #35 - Template builder: add warning for blank template
   #33 - Implement UI for Template CRUD
   #31 - Add "remember size and position" option
   #28 - Implement UI for deleting Queries


### PR DESCRIPTION
This PR addresses issue #35 by adding a warning to the `TemplateBuilderDialog` if the user attempts to create a "blank" Template - that is, a Template that has no date option and no tags entered. There's nothing technically wrong with this configuration, so we don't want to treat this as a validation error. But it's likely not what the user intended to do, so we will show a warning and explain the consequences of it (but still allow them to proceed).