### PR TITLE
Issue #42 - add save prompt on exit if there are unsaved changes

### DIFF
--- a/src/main/java/ca/corbett/snotes/ui/MainWindow.java
+++ b/src/main/java/ca/corbett/snotes/ui/MainWindow.java
@@ -193,6 +193,19 @@ public class MainWindow extends JFrame implements UIReloadable {
             return;
         }
 
+        // Go through all internal frames and dispose them.
+        // If any of them (like WriterFrame) have a save prompt on close,
+        // this will trigger that, giving the user a chance to save their work before we exit.
+        for (JInternalFrame frame : desktopPane.getAllFrames()) {
+            try {
+                frame.toFront();
+                frame.setClosed(true); // don't call dispose()! It bypasses the frame close listener.
+            }
+            catch (PropertyVetoException ignored) {
+                // Just ignore it - application exit can't be canceled at this point
+            }
+        }
+
         // Always save window state, even if "remember state" is disabled:
         AppConfig.getInstance().setWindowProps(getExtendedState(), getWidth(), getHeight(), getX(), getY());
 

--- a/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
@@ -2,6 +2,7 @@ Snotes Release Notes
 Author: Steve Corbett
 
 Version 2.0 [TODO] rewrite
+  #42 - Add save prompt when exiting application
   #40 - Implement WriterFrame, add collision handling
   #37 - Read-only multi-Note viewer
   #35 - Template builder: add warning for blank template


### PR DESCRIPTION
This PR addresses issue #42 by gracefully closing all open internal frames on application exit. This will trigger any frame close listeners, such as the one in `WriterFrame` that will prompt the user to save or discard any changes that have been made.

If there are no internal frames open, or if none of them have frame close listeners configured, there is no visible change from before.

Closes #42 