### PR TITLE
Issue #50 - fix bug in scratch file cleanup

### DIFF
--- a/src/main/java/ca/corbett/snotes/io/DataManager.java
+++ b/src/main/java/ca/corbett/snotes/io/DataManager.java
@@ -176,6 +176,10 @@ public class DataManager {
         }
 
         File savePath = SnotesIO.computeFile(dataDir, note);
+        // Capture the old source file BEFORE saveNote() updates it, so we can clean it up afterwards
+        // regardless of which code path we take below:
+        File oldSourceFile = note.getSourceFile();
+
         if (hasCollision(note)) {
             if (savePath.exists()) {
                 handleNoteCollision(note, savePath, collisionStrategy);
@@ -190,18 +194,23 @@ public class DataManager {
                 throw new IOException("Failed to create directory for note: " + targetDir.getAbsolutePath());
             }
 
-            File oldSourceFile = note.getSourceFile();
             SnotesIO.saveNote(note, savePath); // updates the Note's source file to the new location + marks it clean.
-            if (oldSourceFile != null && oldSourceFile.exists() && !oldSourceFile.equals(savePath)) {
-                if (!oldSourceFile.delete()) {
-                    // This is not fatal, but it is wonky... warn but proceed:
-                    log.warning("Failed to delete old source file for note: " + oldSourceFile.getAbsolutePath());
-                }
-            }
         }
         else {
-            // The Note's source file is the same as the computed save path, so we can just overwrite it.
+            // Either the Note's source file is already at the computed save path (in-place overwrite),
+            // or savePath doesn't exist yet (first-time save with no collision). Save to the computed path.
             SnotesIO.saveNote(note, savePath);
+        }
+
+        // Clean up the old source file if it differs from where we just saved.
+        // This covers both scratch note promotion (no collision path above) and note relocation
+        // (collision path above). Without this step outside the collision block, a scratch file
+        // would survive on disk any time the first save has no collision.
+        if (oldSourceFile != null && oldSourceFile.exists() && !oldSourceFile.equals(savePath)) {
+            if (!oldSourceFile.delete()) {
+                // This is not fatal, but it is wonky... warn but proceed:
+                log.warning("Failed to delete old source file for note: " + oldSourceFile.getAbsolutePath());
+            }
         }
 
         // If this was a scratch note, move it from the scratch list to the main notes list:

--- a/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
@@ -2,6 +2,7 @@ Snotes Release Notes
 Author: Steve Corbett
 
 Version 2.0 [TODO] rewrite
+  #50 - Fix bug regarding scratch file cleanup
   #45 - WriterFrame: show optional context
   #44 - Include update_sources.json for dynamic extensions
   #42 - Add save prompt when exiting application

--- a/src/test/java/ca/corbett/snotes/io/DataManagerTest.java
+++ b/src/test/java/ca/corbett/snotes/io/DataManagerTest.java
@@ -277,6 +277,84 @@ class DataManagerTest {
     }
 
     @Test
+    void save_scratchNote_withNoCollision_shouldDeleteScratchFileFromDisk() throws IOException {
+        // GIVEN a new scratch note with a unique tag so there is no collision:
+        Note note = dataManager.newNote();
+        note.setText("No-collision scratch content");
+        note.tag("no-collision-scratch-delete-test");
+        File scratchFile = note.getSourceFile();
+        assertNotNull(scratchFile);
+        assertTrue(scratchFile.exists(), "Scratch file should exist before save");
+
+        // WHEN we save it (savePath does not exist yet → hasCollision() == false):
+        dataManager.save(note);
+
+        // THEN the scratch file should be gone from disk:
+        assertFalse(scratchFile.exists(),
+                    "Scratch file should have been deleted after a successful save with no collision");
+
+        // AND the note should live in the data directory now:
+        assertNotNull(note.getSourceFile());
+        assertTrue(note.getSourceFile().exists());
+        assertFalse(note.getSourceFile().getAbsolutePath().contains(DataManager.SCRATCH_DIR));
+    }
+
+    @Test
+    void save_scratchNote_withCollisionAndOVERWRITE_shouldDeleteScratchFileFromDisk() throws IOException {
+        // GIVEN a note that has already been saved (occupies the collision target path):
+        Note firstNote = dataManager.newNote();
+        firstNote.tag("scratch-overwrite-cleanup-test");
+        firstNote.setText("I was here first");
+        dataManager.save(firstNote);
+
+        // GIVEN a second scratch note with the same tag, triggering a collision:
+        Note secondNote = dataManager.newNote();
+        secondNote.tag("scratch-overwrite-cleanup-test");
+        secondNote.setText("I will overwrite the first");
+        File secondScratchFile = secondNote.getSourceFile();
+        assertNotNull(secondScratchFile);
+        assertTrue(secondScratchFile.exists(), "Second scratch file should exist before save");
+        assertTrue(dataManager.hasCollision(secondNote));
+
+        // WHEN we save with OVERWRITE:
+        dataManager.save(secondNote, DataManager.CollisionStrategy.OVERWRITE);
+
+        // THEN the second scratch file should have been cleaned up:
+        assertFalse(secondScratchFile.exists(),
+                    "Scratch file should have been deleted after a successful OVERWRITE save");
+    }
+
+    @Test
+    void save_scratchNote_withCollisionAndAPPEND_shouldDeleteScratchFileFromDisk() throws IOException {
+        // GIVEN a note that has already been saved (occupies the collision target path):
+        Note firstNote = dataManager.newNote();
+        firstNote.tag("scratch-append-cleanup-test");
+        firstNote.setText("First content");
+        dataManager.save(firstNote);
+
+        // GIVEN a second scratch note with the same tag, triggering a collision:
+        Note secondNote = dataManager.newNote();
+        secondNote.tag("scratch-append-cleanup-test");
+        secondNote.setText("Appended content");
+        File secondScratchFile = secondNote.getSourceFile();
+        assertNotNull(secondScratchFile);
+        assertTrue(secondScratchFile.exists(), "Second scratch file should exist before save");
+        assertTrue(dataManager.hasCollision(secondNote));
+
+        // WHEN we save with APPEND:
+        dataManager.save(secondNote, DataManager.CollisionStrategy.APPEND);
+
+        // THEN the second scratch file should have been cleaned up:
+        assertFalse(secondScratchFile.exists(),
+                    "Scratch file should have been deleted after a successful APPEND save");
+
+        // AND both notes' content should be present in the saved file:
+        String content = Files.readString(firstNote.getSourceFile().toPath());
+        assertTrue(content.contains("First content"));
+        assertTrue(content.contains("Appended content"));
+    }
+
+    @Test
     void save_datedNote_shouldCreateDateSubdirectoryStructure() throws IOException {
         // GIVEN a dated scratch note:
         Note note = dataManager.newNote();


### PR DESCRIPTION
This PR addresses issue #50 by fixing a bug in the logic of `DataManager.save()` where a scratch file on a first-time save would not be cleaned up after saving successfully to the data directory. Added unit tests to explicitly ensure that scratch files get cleaned up after a successful save.

Closes #50