### PR TITLE
Issue #55 - better progress display on startup

### DIFF
--- a/src/main/java/ca/corbett/snotes/Main.java
+++ b/src/main/java/ca/corbett/snotes/Main.java
@@ -2,16 +2,12 @@ package ca.corbett.snotes;
 
 import ca.corbett.extras.LookAndFeelManager;
 import ca.corbett.extras.SingleInstanceManager;
-import ca.corbett.extras.progress.SimpleProgressWorker;
-import ca.corbett.extras.progress.SplashProgressWindow;
 import ca.corbett.snotes.extensions.SnotesExtensionManager;
 import ca.corbett.snotes.ui.MainWindow;
 import ca.corbett.updates.UpdateManager;
 import ca.corbett.updates.UpdateSources;
 
-import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
-import java.awt.Color;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -102,9 +98,9 @@ public class Main {
         // so that dynamic extension discovery and download will be available:
         parseUpdateSources();
 
-        // Show the splash progress screen, which will show the main window when done:
-        SplashProgressWindow splashWindow = new SplashProgressWindow(Color.GRAY, Color.BLACK, Resources.getLogoWide());
-        splashWindow.runWorker(new StartupWorker(mainWindow));
+        // Now show the main window. It has an async loader on startup that will show
+        // a progress dialog after the main window comes up:
+        SwingUtilities.invokeLater(() -> mainWindow.setVisible(true));
     }
 
     /**
@@ -198,29 +194,6 @@ public class Main {
             // Not an error, just means that we won't be able to pick up extensions dynamically.
             // User can still load extensions by manually dropping the jar file into our extensions directory.
             logger.log(Level.INFO, "No update sources provided. Dynamic extension discovery disabled.");
-        }
-    }
-
-    /**
-     * A worker thread to perform one-time startup tasks and report progress to the splash screen progress bar.
-     */
-    private static class StartupWorker extends SimpleProgressWorker {
-
-        private final JFrame window;
-
-        public StartupWorker(JFrame window) {
-            this.window = window;
-        }
-
-        @Override
-        public void run() {
-            // TODO here is where we load all Snotes files, which may take quite some time.
-            // We can fire progress events as we go, and the splash screen's progress bar will update.
-            // For now, let's just pretend we finished the work in one step:
-            fireProgressComplete();
-
-            // Once complete, we can show the main window on the EDT thread:
-            SwingUtilities.invokeLater(() -> window.setVisible(true));
         }
     }
 }

--- a/src/main/java/ca/corbett/snotes/ui/MainWindow.java
+++ b/src/main/java/ca/corbett/snotes/ui/MainWindow.java
@@ -4,6 +4,7 @@ import ca.corbett.extras.CustomizableDesktopPane;
 import ca.corbett.extras.MessageUtil;
 import ca.corbett.extras.SingleInstanceManager;
 import ca.corbett.extras.actionpanel.ActionPanel;
+import ca.corbett.extras.image.animation.BlurLayerUI;
 import ca.corbett.extras.io.KeyStrokeManager;
 import ca.corbett.extras.logging.LogConsole;
 import ca.corbett.extras.properties.KeyStrokeProperty;
@@ -19,9 +20,11 @@ import ca.corbett.updates.UpdateManager;
 
 import javax.swing.JFrame;
 import javax.swing.JInternalFrame;
+import javax.swing.JLayer;
 import javax.swing.JSplitPane;
 import javax.swing.SwingUtilities;
 import java.awt.BorderLayout;
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
@@ -31,9 +34,19 @@ import java.util.logging.Logger;
 
 /**
  * The main window for the Snotes application.
- * TODO this needs a lot of work...
+ * On initial startup, all notes will be loaded in a background thread, while a progress dialog
+ * is shown. The UI will not be interactive until this initial load completes. If the initial
+ * load is interrupted via the "cancel" button on the progress dialog, only those notes that
+ * were loaded before the operation was canceled will be available in the UI.
+ * <p>
+ *     Note that this initial load creates a complete cache in memory of all notes.
+ *     All searches are done in this in-memory cache. The assumption is that disk
+ *     contents will not change while the application is running. There is currently
+ *     no way to force a reload after the initial load.
+ * </p>
  *
  * @author scorbo2
+ * @since Snotes 2.0
  */
 public class MainWindow extends JFrame implements UIReloadable {
 
@@ -42,6 +55,7 @@ public class MainWindow extends JFrame implements UIReloadable {
     private final MessageUtil messageUtil;
     private boolean isSingleInstanceModeEnabled;
     private final ActionPanelManager actionPanelManager;
+    private final BlurLayerUI blurLayer;
     private final KeyStrokeManager keyStrokeManager;
     private final DataManager dataManager;
     private volatile UpdateManager updateManager;
@@ -64,6 +78,11 @@ public class MainWindow extends JFrame implements UIReloadable {
         dataManager.addNoteDeletionListener(this::noteDeleted);
         keyStrokeManager = new KeyStrokeManager(this);
         actionPanelManager = new ActionPanelManager();
+        blurLayer = new BlurLayerUI();
+        blurLayer.setBlurOverlayColor(Color.LIGHT_GRAY);
+        blurLayer.setOverlayTextColor(Color.WHITE);
+        blurLayer.setOverlayTextSize(24);
+        blurLayer.setOverlayText("Loading...");
         initComponents();
         addWindowListener(new WindowCloseHandler());
         cleanupComplete = false;
@@ -94,6 +113,7 @@ public class MainWindow extends JFrame implements UIReloadable {
             // Tell our DataManager to load everything (background thread), and then trigger a UI reload when finished:
             try {
                 initialLoad = true;
+                blurLayer.setBlurred(true);
                 dataManager.loadAll(e -> reloadUI());
             }
             catch (IOException ioe) {
@@ -193,7 +213,7 @@ public class MainWindow extends JFrame implements UIReloadable {
 
         JSplitPane splitPane = new JSplitPane();
         splitPane.setOneTouchExpandable(false); // Sadly, this does not play well with some look and feels
-        splitPane.setLeftComponent(actionPanelManager.getActionPanel());
+        splitPane.setLeftComponent(new JLayer<>(actionPanelManager.getActionPanel(), blurLayer));
         splitPane.setRightComponent(desktopPane);
         splitPane.setDividerLocation(0.25);
 
@@ -271,6 +291,12 @@ public class MainWindow extends JFrame implements UIReloadable {
 
         // The actions in our ActionManager may need refreshing:
         actionPanelManager.reload();
+
+        // If we were blurred for the initial load, unblur now with a little animation:
+        // (we delay this until after ActionPanel is populated so the "unblur" animation is more dramatic)
+        if (blurLayer.isBlurred()) {
+            blurLayer.blurIn(null);
+        }
 
         // Clear all keystrokes and reload, since they are all user-configurable:
         keyStrokeManager.clear();

--- a/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
@@ -3,6 +3,7 @@ Author: Steve Corbett
 
 Version 2.0 [TODO] rewrite
   #56 - Wire up UpdateManager for dynamic extensions
+  #55 - Better progress display on initial load
   #52 - Better options for discarding scratch notes
   #50 - Fix bug regarding scratch file cleanup
   #45 - WriterFrame: show optional context


### PR DESCRIPTION
This PR addresses issue #55 by adding a blur overlay to our ActionPanel while the initial load is done at application startup. The blur effect is removed with a short animation after the initial load completes. 

Removed old code related to showing a SplashProgressWindow on startup, since this is now handled within MainWindow. 

Closes #55 