### PR TITLE
Issue #62 - auto-restart when changing data dirs

### DIFF
--- a/src/main/java/ca/corbett/snotes/Main.java
+++ b/src/main/java/ca/corbett/snotes/Main.java
@@ -4,7 +4,6 @@ import ca.corbett.extras.LookAndFeelManager;
 import ca.corbett.extras.SingleInstanceManager;
 import ca.corbett.snotes.extensions.SnotesExtensionManager;
 import ca.corbett.snotes.ui.MainWindow;
-import ca.corbett.updates.UpdateManager;
 import ca.corbett.updates.UpdateSources;
 
 import javax.swing.SwingUtilities;
@@ -161,22 +160,26 @@ public class Main {
         if (Version.UPDATE_SOURCES_FILE != null) {
             try {
                 UpdateSources updateSources = UpdateSources.fromFile(Version.UPDATE_SOURCES_FILE);
-                UpdateManager updateManager = new UpdateManager(updateSources);
+                SnotesUpdateManager updateManager = new SnotesUpdateManager(updateSources);
                 MainWindow.getInstance().setUpdateManager(updateManager);
 
+                // See the javadocs in SnotesUpdateManager for an explanation of why we
+                // aren't registering a shutdown hook here. Don't remove the following commented code!
+                // We'll restore it when the underlying bug in UpdateManager is fixed.
+
                 // Let's register a shutdown hook for when UpdateManager restarts the app to pick up new extensions:
-                updateManager.registerShutdownHook(() -> {
-                    if (SwingUtilities.isEventDispatchThread()) {
-                        MainWindow.getInstance().cleanup();
-                    } else {
-                        try {
-                            SwingUtilities.invokeAndWait(() -> MainWindow.getInstance().cleanup());
-                        } catch (Exception e) {
-                            Logger.getLogger(Main.class.getName())
-                                  .log(Level.WARNING, "Error during MainWindow cleanup in shutdown hook.", e);
-                        }
-                    }
-                });
+//                updateManager.registerShutdownHook(() -> {
+//                    if (SwingUtilities.isEventDispatchThread()) {
+//                        MainWindow.getInstance().cleanup();
+//                    } else {
+//                        try {
+//                            SwingUtilities.invokeAndWait(() -> MainWindow.getInstance().cleanup());
+//                        } catch (Exception e) {
+//                            Logger.getLogger(Main.class.getName())
+//                                  .log(Level.WARNING, "Error during MainWindow cleanup in shutdown hook.", e);
+//                        }
+//                    }
+//                });
 
                 // Let our AboutInfo know about this too, so the About dialog can do application version checks:
                 Version.getAboutInfo().updateManager = updateManager;

--- a/src/main/java/ca/corbett/snotes/SnotesUpdateManager.java
+++ b/src/main/java/ca/corbett/snotes/SnotesUpdateManager.java
@@ -1,0 +1,46 @@
+package ca.corbett.snotes;
+
+import ca.corbett.snotes.ui.MainWindow;
+import ca.corbett.updates.UpdateManager;
+import ca.corbett.updates.UpdateSources;
+
+/**
+ * Issue <a href="https://github.com/scorbo2/swing-extras/issues/433">#433</a> in the swing-extras
+ * library describes a problem that can occur if an application registers a shutdown hook
+ * that needs to do UI cleanup. In our case, if our user tries to close the application with
+ * unsaved changes in any internal frame, we show a popup dialog asking to save or discard changes.
+ * This is a problem, because the current implementation of UpdateManager blocks the EDT during
+ * application restarts. This leads to deadlocks when Snotes tries to restart itself.
+ * <p>
+ * Until the bug is fixed upstream, here is our workaround: extend the UpdateManager
+ * class and override the restartApplication() method to do our UI cleanup BEFORE calling
+ * the superclass method. Then, we avoid registering a shutdown hook at all, and we
+ * avoid deadlocks, while retaining the benefit of being able to restart as needed.
+ * When the bug is patched upstream, we can simply remove this class.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since Snotes 2.0
+ */
+public class SnotesUpdateManager extends UpdateManager {
+
+    public SnotesUpdateManager(UpdateSources sources) {
+        super(sources);
+
+        // Register a dummy shutdown hook to avoid the "you have no shutdown hooks registered!" warning.
+        registerShutdownHook(() -> {
+            // Deliberate no-op. We'll handle cleanup ourselves.
+        });
+    }
+
+    @Override
+    public void restartApplication() {
+        // Because this method is invoked on the EDT, we can safely invoke
+        // our cleanup method here. We can prompt the user, close all internal
+        // frames, and whatever else we need to do.
+        MainWindow.getInstance().cleanup();
+
+        // Then, once we're cleaned up, we can let UpdateManager handle the restart:
+        super.restartApplication();
+    }
+}

--- a/src/main/java/ca/corbett/snotes/ui/actions/ExecuteQueryAction.java
+++ b/src/main/java/ca/corbett/snotes/ui/actions/ExecuteQueryAction.java
@@ -14,7 +14,6 @@ import java.util.logging.Logger;
 
 /**
  * This action takes a Query and executes it, showing the results in a new frame.
- * TODO this is a placeholder until the UI is ready for it.
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  */

--- a/src/main/java/ca/corbett/snotes/ui/actions/PrefsAction.java
+++ b/src/main/java/ca/corbett/snotes/ui/actions/PrefsAction.java
@@ -4,6 +4,7 @@ import ca.corbett.extras.EnhancedAction;
 import ca.corbett.extras.MessageUtil;
 import ca.corbett.snotes.AppConfig;
 import ca.corbett.snotes.ui.MainWindow;
+import ca.corbett.updates.UpdateManager;
 
 import java.awt.event.ActionEvent;
 import java.io.File;
@@ -32,12 +33,19 @@ public class PrefsAction extends EnhancedAction {
             // If the data directory changed, we need to restart the application:
             File newDataDirectory = AppConfig.getInstance().getDataDirectory();
             if (!dataDirectory.getAbsolutePath().equals(newDataDirectory.getAbsolutePath())) {
-                getMessageUtil().info("Restart required",
-                                      "Changing the data directory requires restarting the application.");
 
-                // TODO once we have wired up the UpdateManager (future ticket),
-                //      we can restart the application automatically.
-                //      Until then, all we can do is nag the user to do it for us.
+                // We can restart automatically, if an UpdateManager is configured:
+                UpdateManager updateManager = MainWindow.getInstance().getUpdateManager();
+                if (updateManager != null) {
+                    // Will restart if user confirms:
+                    updateManager.showApplicationRestartPrompt(MainWindow.getInstance());
+                }
+
+                // Otherwise, all we can do is nag the user to do it for us:
+                else {
+                    getMessageUtil().info("Restart required",
+                                          "Changing the data directory requires restarting the application.");
+                }
             }
 
             // If the user clicked OK, reload the UI:

--- a/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
@@ -2,6 +2,7 @@ Snotes Release Notes
 Author: Steve Corbett
 
 Version 2.0 [TODO] rewrite
+  #62 - Implement auto-restart when changing data dirs
   #59 - Add limit option on search dialog
   #56 - Wire up UpdateManager for dynamic extensions
   #55 - Better progress display on initial load


### PR DESCRIPTION
This PR addresses issue #62 by using our `UpdateManager` instance (if configured) to handle automatically restarting the application when the user changes our persistence directory. 

While implementing this, I found a bug in the upstream `swing-extras` library that requires a workaround in this application code to avoid deadlocks in our shutdown hooks. This workaround is invisible to the user and is trivial to remove later, when the upstream bug is eventually fixed. Issue [433](https://github.com/scorbo2/swing-extras/issues/433) in `swing-extras` contains the details.

Closes #62 