### PR TITLE
Issue #66 - allow manual reordering of Queries and Templates

### DIFF
--- a/src/main/java/ca/corbett/snotes/io/DataManager.java
+++ b/src/main/java/ca/corbett/snotes/io/DataManager.java
@@ -14,6 +14,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -469,7 +470,11 @@ public class DataManager {
         // If this Template wasn't already in our cache, add it now:
         if (!templates.contains(template)) {
             templates.add(template);
+            applyTemplateOrdering();
         }
+
+        // Re-apply our template ordering, in case it has changed:
+        applyTemplateOrdering();
     }
 
     /**
@@ -512,7 +517,11 @@ public class DataManager {
         // If this Query wasn't already in our cache, add it now:
         if (!queries.contains(query)) {
             queries.add(query);
+            applyQueryOrdering();
         }
+
+        // Re-apply our query ordering, in case it has changed:
+        applyQueryOrdering();
     }
 
     /**
@@ -710,19 +719,41 @@ public class DataManager {
         this.notes.addAll(notes);
     }
 
-    private void setQueries(List<Query> queries) {
+    void setQueries(List<Query> queries) {
         this.queries.clear();
         this.queries.addAll(queries);
+        applyQueryOrdering();
     }
 
-    private void setTemplates(List<Template> templates) {
+    void setTemplates(List<Template> templates) {
         this.templates.clear();
         this.templates.addAll(templates);
+        applyTemplateOrdering();
     }
 
     private void setScratchNotes(List<Note> scratchNotes) {
         this.scratchNotes.clear();
         this.scratchNotes.addAll(scratchNotes);
+    }
+
+    /**
+     * Invoked whenever Query instances are added. We order Queries first
+     * by their "order" attribute, and then alphabetically by their source filename as a tiebreaker.
+     */
+    private void applyQueryOrdering() {
+        queries.sort(Comparator
+                         .comparingInt(Query::getOrder)
+                         .thenComparing(q -> q.getSourceFile() != null ? q.getSourceFile().getName() : ""));
+    }
+
+    /**
+     * Invoked whenever Template instances are added. We order Templates first
+     * by their "order" attribute, and then alphabetically by their source filename as a tiebreaker.
+     */
+    private void applyTemplateOrdering() {
+        templates.sort(Comparator
+                           .comparingInt(Template::getOrder)
+                           .thenComparing(t -> t.getSourceFile() != null ? t.getSourceFile().getName() : ""));
     }
 
     /**

--- a/src/main/java/ca/corbett/snotes/io/DataManager.java
+++ b/src/main/java/ca/corbett/snotes/io/DataManager.java
@@ -470,7 +470,6 @@ public class DataManager {
         // If this Template wasn't already in our cache, add it now:
         if (!templates.contains(template)) {
             templates.add(template);
-            applyTemplateOrdering();
         }
 
         // Re-apply our template ordering, in case it has changed:
@@ -517,7 +516,6 @@ public class DataManager {
         // If this Query wasn't already in our cache, add it now:
         if (!queries.contains(query)) {
             queries.add(query);
-            applyQueryOrdering();
         }
 
         // Re-apply our query ordering, in case it has changed:

--- a/src/main/java/ca/corbett/snotes/io/SnotesIO.java
+++ b/src/main/java/ca/corbett/snotes/io/SnotesIO.java
@@ -76,6 +76,12 @@ class SnotesIO {
             }
         }
 
+        // Load order if present; default to 0 for older persisted Queries that lack the field:
+        JsonNode orderNode = rootNode.get("order");
+        if (orderNode != null && !orderNode.isNull() && orderNode.isNumber()) {
+            query.setOrder(orderNode.asInt(0));
+        }
+
         query.setSourceFile(sourceFile);
         query.markClean();
         return query;
@@ -108,6 +114,7 @@ class SnotesIO {
         ObjectMapper mapper = new ObjectMapper();
         ObjectNode rootNode = mapper.createObjectNode();
         rootNode.put("name", query.getName());
+        rootNode.put("order", query.getOrder());
 
         ArrayNode filtersArray = mapper.createArrayNode();
         for (Filter filter : query.getFilters()) {
@@ -160,6 +167,7 @@ class SnotesIO {
         rootNode.put("name", template.getName());
         rootNode.put("dateOption", template.getDateOption().name());
         rootNode.put("context", template.getContext().name());
+        rootNode.put("order", template.getOrder());
         ArrayNode tagsArray = rootNode.putArray("tags");
         for (Tag tag : template.getTagList()) {
             tagsArray.add(tag.getTag()); // get raw tag without the '#' prefix for cleaner JSON
@@ -266,6 +274,13 @@ class SnotesIO {
         for (String tag : tagList) {
             template.addTag(tag);
         }
+
+        // Load order if present; default to 0 for older persisted Templates that lack the field:
+        JsonNode orderNode = rootNode.get("order");
+        if (orderNode != null && !orderNode.isNull() && orderNode.isNumber()) {
+            template.setOrder(orderNode.asInt(0));
+        }
+
         template.setSourceFile(sourceFile);
         template.markClean();
         return template;

--- a/src/main/java/ca/corbett/snotes/model/Query.java
+++ b/src/main/java/ca/corbett/snotes/model/Query.java
@@ -26,6 +26,7 @@ public class Query {
     private final List<Filter> filters;
     private File sourceFile;
     private boolean isDirty;
+    private int order;
 
     /**
      * Creates an empty, unnamed Query with no filters.
@@ -37,6 +38,7 @@ public class Query {
         name = DEFAULT_NAME;
         sourceFile = null;
         isDirty = true;
+        order = 0;
     }
 
     /**
@@ -202,6 +204,24 @@ public class Query {
         }
 
         return filteredNotes;
+    }
+
+    /**
+     * Returns the sort order for this Query. Lower values sort first. Defaults to 0.
+     */
+    public int getOrder() {
+        return order;
+    }
+
+    /**
+     * Sets the sort order for this Query. Lower values sort first.
+     */
+    public void setOrder(int order) {
+        if (this.order == order) {
+            return; // No change, so don't mark dirty
+        }
+        this.order = order;
+        isDirty = true;
     }
 
     /**

--- a/src/main/java/ca/corbett/snotes/model/Template.java
+++ b/src/main/java/ca/corbett/snotes/model/Template.java
@@ -95,6 +95,7 @@ public class Template {
     private final List<Tag> tagList;
     private File sourceFile;
     private boolean isDirty;
+    private int order;
 
     /**
      * Creates a new, empty, unnamed Template.
@@ -114,6 +115,7 @@ public class Template {
         this.context = Context.NONE;
         this.tagList = new ArrayList<>();
         this.sourceFile = null;
+        this.order = 0;
         isDirty = true;
     }
 
@@ -230,6 +232,24 @@ public class Template {
      */
     public List<Tag> getTagList() {
         return new ArrayList<>(tagList);
+    }
+
+    /**
+     * Returns the sort order for this Template. Lower values sort first. Defaults to 0.
+     */
+    public int getOrder() {
+        return order;
+    }
+
+    /**
+     * Sets the sort order for this Template. Lower values sort first.
+     */
+    public void setOrder(int order) {
+        if (this.order == order) {
+            return; // No change, so don't mark dirty
+        }
+        this.order = order;
+        isDirty = true;
     }
 
     /**

--- a/src/main/java/ca/corbett/snotes/ui/query/ManageQueriesDialog.java
+++ b/src/main/java/ca/corbett/snotes/ui/query/ManageQueriesDialog.java
@@ -72,7 +72,7 @@ public class ManageQueriesDialog extends JDialog {
         keyManager.dispose();
         setVisible(false);
         dispose();
-        
+
         if (listReordered) {
             // Trigger a UI reload so the list of queries in the ActionPanel are updated:
             UIReloadAction.getInstance().actionPerformed(null);
@@ -117,7 +117,7 @@ public class ManageQueriesDialog extends JDialog {
         moveDownAction.setTooltip(moveDownAction.getTooltip() + " (Ctrl+Down)");
         queryListField.addButton(moveUpAction);
         queryListField.addButton(moveDownAction);
-        queryListField.addListDataListener(new ListListener());
+        queryListField.addListDataListener(listListener);
 
         formPanel.add(queryListField);
 

--- a/src/main/java/ca/corbett/snotes/ui/query/ManageQueriesDialog.java
+++ b/src/main/java/ca/corbett/snotes/ui/query/ManageQueriesDialog.java
@@ -1,20 +1,25 @@
 package ca.corbett.snotes.ui.query;
 
+import ca.corbett.extras.EnhancedAction;
 import ca.corbett.extras.MessageUtil;
 import ca.corbett.extras.io.KeyStrokeManager;
 import ca.corbett.forms.Alignment;
 import ca.corbett.forms.FormPanel;
+import ca.corbett.forms.SwingFormsResources;
+import ca.corbett.forms.actions.ListItemMoveAction;
 import ca.corbett.forms.fields.ListField;
 import ca.corbett.snotes.io.DataManager;
 import ca.corbett.snotes.model.Query;
 import ca.corbett.snotes.ui.MainWindow;
 import ca.corbett.snotes.ui.actions.UIReloadAction;
 
-import javax.swing.AbstractAction;
+import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JPanel;
 import javax.swing.ListSelectionModel;
+import javax.swing.event.ListDataEvent;
+import javax.swing.event.ListDataListener;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
@@ -34,9 +39,14 @@ public class ManageQueriesDialog extends JDialog {
     private static final Logger log = Logger.getLogger(ManageQueriesDialog.class.getName());
     private MessageUtil messageUtil;
 
+    private final ListListener listListener;
+    private ListItemMoveAction<Query> moveUpAction;
+    private ListItemMoveAction<Query> moveDownAction;
+
     private final KeyStrokeManager keyManager;
     private final DataManager dataManager;
     private ListField<Query> queryListField;
+    private boolean listReordered;
 
     public ManageQueriesDialog() {
         super(MainWindow.getInstance(), "Manage Queries", true);
@@ -44,9 +54,15 @@ public class ManageQueriesDialog extends JDialog {
         setResizable(false);
         setLocationRelativeTo(MainWindow.getInstance());
         setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
+        this.listListener = new ListListener();
+        this.listReordered = false;
         this.dataManager = MainWindow.getInstance().getDataManager();
         keyManager = new KeyStrokeManager(this);
         keyManager.registerHandler(KeyStrokeManager.parseKeyStroke("ESC"), e -> closeDialog());
+        keyManager.registerHandler(KeyStrokeManager.parseKeyStroke("Ctrl+up"),
+                                   e -> moveUpAction.actionPerformed(e));
+        keyManager.registerHandler(KeyStrokeManager.parseKeyStroke("Ctrl+down"),
+                                   e -> moveDownAction.actionPerformed(e));
         setLayout(new BorderLayout());
         add(buildFormPanel(), BorderLayout.CENTER);
         add(buildButtonPanel(), BorderLayout.SOUTH);
@@ -56,16 +72,27 @@ public class ManageQueriesDialog extends JDialog {
         keyManager.dispose();
         setVisible(false);
         dispose();
+        
+        if (listReordered) {
+            // Trigger a UI reload so the list of queries in the ActionPanel are updated:
+            UIReloadAction.getInstance().actionPerformed(null);
+        }
     }
 
     /**
      * Forces a refresh of the list of Queries displayed here.
      */
     private void refresh() {
-        queryListField.getListModel().clear();
-        queryListField.getListModel().addAll(dataManager.getQueries());
-        queryListField.getList().revalidate();
-        queryListField.getList().repaint();
+        queryListField.removeListDataListener(listListener);
+        try {
+            queryListField.getListModel().clear();
+            queryListField.getListModel().addAll(dataManager.getQueries());
+            queryListField.getList().revalidate();
+            queryListField.getList().repaint();
+        }
+        finally {
+            queryListField.addListDataListener(listListener);
+        }
     }
 
     private JPanel buildFormPanel() {
@@ -77,10 +104,21 @@ public class ManageQueriesDialog extends JDialog {
         queryListField.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         queryListField.setShouldExpand(true);
         queryListField.setButtonPosition(ListField.ButtonPosition.BOTTOM);
-        queryListField.setButtonLayout(FlowLayout.LEFT, 6, 4);
+        queryListField.setButtonLayout(FlowLayout.CENTER, 2, 2);
+        queryListField.setButtonPanelBorder(BorderFactory.createLoweredBevelBorder());
         queryListField.addButton(new AddQueryAction());
         queryListField.addButton(new EditQueryAction());
         queryListField.addButton(new DeleteQueryAction());
+        this.moveUpAction = new ListItemMoveAction<>(SwingFormsResources.getMoveUpIcon(16), queryListField,
+                                                     ListItemMoveAction.Direction.UP);
+        moveUpAction.setTooltip(moveUpAction.getTooltip() + " (Ctrl+Up)");
+        this.moveDownAction = new ListItemMoveAction<>(SwingFormsResources.getMoveDownIcon(16), queryListField,
+                                                       ListItemMoveAction.Direction.DOWN);
+        moveDownAction.setTooltip(moveDownAction.getTooltip() + " (Ctrl+Down)");
+        queryListField.addButton(moveUpAction);
+        queryListField.addButton(moveDownAction);
+        queryListField.addListDataListener(new ListListener());
+
         formPanel.add(queryListField);
 
         return formPanel;
@@ -100,9 +138,10 @@ public class ManageQueriesDialog extends JDialog {
      * After the dialog is closed, if a new Query was created, it will be saved
      * and the list of Queries will be refreshed.
      */
-    private class AddQueryAction extends AbstractAction {
+    private class AddQueryAction extends EnhancedAction {
         public AddQueryAction() {
-            super("New");
+            super("", SwingFormsResources.getAddIcon(16));
+            setTooltip("Create a new query");
         }
 
         @Override
@@ -133,9 +172,10 @@ public class ManageQueriesDialog extends JDialog {
      * After the dialog is closed, if the Query was updated, it will be saved
      * and the list of Queries will be refreshed.
      */
-    private class EditQueryAction extends AbstractAction {
+    private class EditQueryAction extends EnhancedAction {
         public EditQueryAction() {
-            super("Edit");
+            super("", SwingFormsResources.getEditIcon(16));
+            setTooltip("Edit the selected query");
         }
 
         @Override
@@ -171,9 +211,10 @@ public class ManageQueriesDialog extends JDialog {
      * An internal action to delete the selected Query.
      * After confirming with the user, the Query will be deleted and the list of Queries will be refreshed.
      */
-    private class DeleteQueryAction extends AbstractAction {
+    private class DeleteQueryAction extends EnhancedAction {
         public DeleteQueryAction() {
-            super("Delete");
+            super("", SwingFormsResources.getRemoveIcon(16));
+            setTooltip("Delete the selected query");
         }
 
         @Override
@@ -195,6 +236,51 @@ public class ManageQueriesDialog extends JDialog {
                 // Also refresh our own list:
                 refresh();
             }
+        }
+    }
+
+    /**
+     * Listens for list re-ordering events, so we can update our Queries accordingly.
+     * Note that we do this against the model objects directly - this dialog does not
+     * have an OK/Cancel setup. Any changes you make here are live.
+     */
+    private class ListListener implements ListDataListener {
+
+        @Override
+        public void intervalAdded(ListDataEvent e) {
+            boolean isDirty = false;
+            for (int i = 0; i < queryListField.getListModel().size(); i++) {
+                Query query = queryListField.getListModel().get(i);
+                query.setOrder(i);
+                isDirty = isDirty || query.isDirty();
+            }
+
+            // If any query is dirty, save 'em all:
+            if (isDirty) {
+                try {
+                    for (int i = 0; i < queryListField.getListModel().size(); i++) {
+                        dataManager.saveQuery(queryListField.getListModel().get(i));
+                    }
+
+                    // Make a note that we did this so we can reload the UI when the dialog closes:
+                    listReordered = true;
+                }
+                catch (IOException ioe) {
+                    getMessageUtil().error("Save error",
+                                           "An error occurred while saving the updated query order: " + ioe.getMessage(),
+                                           ioe);
+                }
+            }
+        }
+
+        @Override
+        public void intervalRemoved(ListDataEvent e) {
+            // ignored
+        }
+
+        @Override
+        public void contentsChanged(ListDataEvent e) {
+            // ignored
         }
     }
 

--- a/src/main/java/ca/corbett/snotes/ui/template/ManageTemplatesDialog.java
+++ b/src/main/java/ca/corbett/snotes/ui/template/ManageTemplatesDialog.java
@@ -1,20 +1,25 @@
 package ca.corbett.snotes.ui.template;
 
+import ca.corbett.extras.EnhancedAction;
 import ca.corbett.extras.MessageUtil;
 import ca.corbett.extras.io.KeyStrokeManager;
 import ca.corbett.forms.Alignment;
 import ca.corbett.forms.FormPanel;
+import ca.corbett.forms.SwingFormsResources;
+import ca.corbett.forms.actions.ListItemMoveAction;
 import ca.corbett.forms.fields.ListField;
 import ca.corbett.snotes.io.DataManager;
 import ca.corbett.snotes.model.Template;
 import ca.corbett.snotes.ui.MainWindow;
 import ca.corbett.snotes.ui.actions.UIReloadAction;
 
-import javax.swing.AbstractAction;
+import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JPanel;
 import javax.swing.ListSelectionModel;
+import javax.swing.event.ListDataEvent;
+import javax.swing.event.ListDataListener;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
@@ -34,9 +39,14 @@ public class ManageTemplatesDialog extends JDialog {
     private static final Logger log = Logger.getLogger(ManageTemplatesDialog.class.getName());
     private MessageUtil messageUtil;
 
+    private final ListListener listListener;
+    private ListItemMoveAction<Template> moveUpAction;
+    private ListItemMoveAction<Template> moveDownAction;
+
     private final KeyStrokeManager keyManager;
     private final DataManager dataManager;
     private ListField<Template> templateListField;
+    private boolean listReordered;
 
     public ManageTemplatesDialog() {
         super(MainWindow.getInstance(), "Manage Templates", true);
@@ -44,9 +54,15 @@ public class ManageTemplatesDialog extends JDialog {
         setResizable(false);
         setLocationRelativeTo(MainWindow.getInstance());
         setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
+        this.listListener = new ListListener();
+        this.listReordered = false;
         this.dataManager = MainWindow.getInstance().getDataManager();
         keyManager = new KeyStrokeManager(this);
         keyManager.registerHandler(KeyStrokeManager.parseKeyStroke("ESC"), e -> closeDialog());
+        keyManager.registerHandler(KeyStrokeManager.parseKeyStroke("Ctrl+up"),
+                                   e -> moveUpAction.actionPerformed(e));
+        keyManager.registerHandler(KeyStrokeManager.parseKeyStroke("Ctrl+down"),
+                                   e -> moveDownAction.actionPerformed(e));
         setLayout(new BorderLayout());
         add(buildFormPanel(), BorderLayout.CENTER);
         add(buildButtonPanel(), BorderLayout.SOUTH);
@@ -56,16 +72,27 @@ public class ManageTemplatesDialog extends JDialog {
         keyManager.dispose();
         setVisible(false);
         dispose();
+
+        if (listReordered) {
+            // Trigger a UI reload so the list of queries in the ActionPanel are updated:
+            UIReloadAction.getInstance().actionPerformed(null);
+        }
     }
 
     /**
      * Forces a refresh of the list of Templates displayed here.
      */
     private void refresh() {
-        templateListField.getListModel().clear();
-        templateListField.getListModel().addAll(dataManager.getTemplates());
-        templateListField.getList().revalidate();
-        templateListField.getList().repaint();
+        templateListField.removeListDataListener(listListener);
+        try {
+            templateListField.getListModel().clear();
+            templateListField.getListModel().addAll(dataManager.getTemplates());
+            templateListField.getList().revalidate();
+            templateListField.getList().repaint();
+        }
+        finally {
+            templateListField.addListDataListener(listListener);
+        }
     }
 
     private JPanel buildFormPanel() {
@@ -77,10 +104,21 @@ public class ManageTemplatesDialog extends JDialog {
         templateListField.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         templateListField.setShouldExpand(true);
         templateListField.setButtonPosition(ListField.ButtonPosition.BOTTOM);
+        templateListField.setButtonLayout(FlowLayout.CENTER, 2, 2);
+        templateListField.setButtonPanelBorder(BorderFactory.createLoweredBevelBorder());
         templateListField.setButtonLayout(FlowLayout.LEFT, 6, 4);
         templateListField.addButton(new AddTemplateAction());
         templateListField.addButton(new EditTemplateAction());
         templateListField.addButton(new DeleteTemplateAction());
+        this.moveUpAction = new ListItemMoveAction<>(SwingFormsResources.getMoveUpIcon(16), templateListField,
+                                                     ListItemMoveAction.Direction.UP);
+        moveUpAction.setTooltip(moveUpAction.getTooltip() + " (Ctrl+Up)");
+        this.moveDownAction = new ListItemMoveAction<>(SwingFormsResources.getMoveDownIcon(16), templateListField,
+                                                       ListItemMoveAction.Direction.DOWN);
+        moveDownAction.setTooltip(moveDownAction.getTooltip() + " (Ctrl+Down)");
+        templateListField.addButton(moveUpAction);
+        templateListField.addButton(moveDownAction);
+        templateListField.addListDataListener(new ListListener());
         formPanel.add(templateListField);
 
         return formPanel;
@@ -100,9 +138,10 @@ public class ManageTemplatesDialog extends JDialog {
      * After the dialog is closed, if a new Template was created, it will be saved
      * and the list of Templates will be refreshed.
      */
-    private class AddTemplateAction extends AbstractAction {
+    private class AddTemplateAction extends EnhancedAction {
         public AddTemplateAction() {
-            super("New");
+            super("", SwingFormsResources.getAddIcon(16));
+            setTooltip("Add a new template");
         }
 
         @Override
@@ -133,9 +172,10 @@ public class ManageTemplatesDialog extends JDialog {
      * After the dialog is closed, if the Template was updated, it will be saved
      * and the list of Templates will be refreshed.
      */
-    private class EditTemplateAction extends AbstractAction {
+    private class EditTemplateAction extends EnhancedAction {
         public EditTemplateAction() {
-            super("Edit");
+            super("", SwingFormsResources.getEditIcon(16));
+            setTooltip("Edit the selected template");
         }
 
         @Override
@@ -171,9 +211,10 @@ public class ManageTemplatesDialog extends JDialog {
      * An internal action to delete the selected Template.
      * After confirming with the user, the Template will be deleted and the list of Templates will be refreshed.
      */
-    private class DeleteTemplateAction extends AbstractAction {
+    private class DeleteTemplateAction extends EnhancedAction {
         public DeleteTemplateAction() {
-            super("Delete");
+            super("", SwingFormsResources.getRemoveIcon(16));
+            setTooltip("Delete the selected template");
         }
 
         @Override
@@ -195,6 +236,51 @@ public class ManageTemplatesDialog extends JDialog {
                 // Also refresh our own list:
                 refresh();
             }
+        }
+    }
+
+    /**
+     * Listens for list re-ordering events, so we can update our Queries accordingly.
+     * Note that we do this against the model objects directly - this dialog does not
+     * have an OK/Cancel setup. Any changes you make here are live.
+     */
+    private class ListListener implements ListDataListener {
+
+        @Override
+        public void intervalAdded(ListDataEvent e) {
+            boolean isDirty = false;
+            for (int i = 0; i < templateListField.getListModel().size(); i++) {
+                Template template = templateListField.getListModel().get(i);
+                template.setOrder(i);
+                isDirty = isDirty || template.isDirty();
+            }
+
+            // If any query is dirty, save 'em all:
+            if (isDirty) {
+                try {
+                    for (int i = 0; i < templateListField.getListModel().size(); i++) {
+                        dataManager.saveTemplate(templateListField.getListModel().get(i));
+                    }
+
+                    // Make a note that we did this so we can reload the UI when the dialog closes:
+                    listReordered = true;
+                }
+                catch (IOException ioe) {
+                    getMessageUtil().error("Save error",
+                                           "An error occurred while saving the updated template order: " + ioe.getMessage(),
+                                           ioe);
+                }
+            }
+        }
+
+        @Override
+        public void intervalRemoved(ListDataEvent e) {
+            // ignored
+        }
+
+        @Override
+        public void contentsChanged(ListDataEvent e) {
+            // ignored
         }
     }
 

--- a/src/main/java/ca/corbett/snotes/ui/template/ManageTemplatesDialog.java
+++ b/src/main/java/ca/corbett/snotes/ui/template/ManageTemplatesDialog.java
@@ -74,7 +74,7 @@ public class ManageTemplatesDialog extends JDialog {
         dispose();
 
         if (listReordered) {
-            // Trigger a UI reload so the list of queries in the ActionPanel are updated:
+            // Trigger a UI reload so the list of templates in the ActionPanel are updated:
             UIReloadAction.getInstance().actionPerformed(null);
         }
     }
@@ -106,7 +106,6 @@ public class ManageTemplatesDialog extends JDialog {
         templateListField.setButtonPosition(ListField.ButtonPosition.BOTTOM);
         templateListField.setButtonLayout(FlowLayout.CENTER, 2, 2);
         templateListField.setButtonPanelBorder(BorderFactory.createLoweredBevelBorder());
-        templateListField.setButtonLayout(FlowLayout.LEFT, 6, 4);
         templateListField.addButton(new AddTemplateAction());
         templateListField.addButton(new EditTemplateAction());
         templateListField.addButton(new DeleteTemplateAction());
@@ -118,7 +117,7 @@ public class ManageTemplatesDialog extends JDialog {
         moveDownAction.setTooltip(moveDownAction.getTooltip() + " (Ctrl+Down)");
         templateListField.addButton(moveUpAction);
         templateListField.addButton(moveDownAction);
-        templateListField.addListDataListener(new ListListener());
+        templateListField.addListDataListener(listListener);
         formPanel.add(templateListField);
 
         return formPanel;
@@ -240,7 +239,7 @@ public class ManageTemplatesDialog extends JDialog {
     }
 
     /**
-     * Listens for list re-ordering events, so we can update our Queries accordingly.
+     * Listens for list re-ordering events, so we can update our Templates accordingly.
      * Note that we do this against the model objects directly - this dialog does not
      * have an OK/Cancel setup. Any changes you make here are live.
      */
@@ -255,7 +254,7 @@ public class ManageTemplatesDialog extends JDialog {
                 isDirty = isDirty || template.isDirty();
             }
 
-            // If any query is dirty, save 'em all:
+            // If any template is dirty, save 'em all:
             if (isDirty) {
                 try {
                     for (int i = 0; i < templateListField.getListModel().size(); i++) {

--- a/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
@@ -2,7 +2,7 @@ Snotes Release Notes
 Author: Steve Corbett
 
 Version 2.0 [TODO] rewrite
-  #66 - Allow manual reordering of Queries and templates
+  #66 - Allow manual reordering of Queries and Templates
   #62 - Implement auto-restart when changing data dirs
   #59 - Add limit option on search dialog
   #56 - Wire up UpdateManager for dynamic extensions

--- a/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
@@ -2,6 +2,7 @@ Snotes Release Notes
 Author: Steve Corbett
 
 Version 2.0 [TODO] rewrite
+  #66 - Allow manual reordering of Queries and templates
   #62 - Implement auto-restart when changing data dirs
   #59 - Add limit option on search dialog
   #56 - Wire up UpdateManager for dynamic extensions

--- a/src/test/java/ca/corbett/snotes/io/DataManagerTest.java
+++ b/src/test/java/ca/corbett/snotes/io/DataManagerTest.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -806,5 +807,104 @@ class DataManagerTest {
         catch (IOException ioe) {
             fail("Unexpected IOException during test setup: " + ioe.getMessage());
         }
+    }
+
+    @Test
+    void setTemplates_withNoOrderSet_shouldOrderByFilename() {
+        // GIVEN some templates with no order set:
+        Template t1 = new Template();
+        t1.setName("t1");
+        t1.setSourceFile(new File(tempDir, "t1.template"));
+        Template t2 = new Template();
+        t2.setName("t2");
+        t2.setSourceFile(new File(tempDir, "t2.template"));
+        Template t3 = new Template();
+        t3.setName("t3");
+        t3.setSourceFile(new File(tempDir, "t3.template"));
+
+        // WHEN we set them in a random order:
+        dataManager.setTemplates(List.of(t2, t3, t1));
+
+        // THEN they should be set according to the tiebreaker sort, which is filename:
+        assertEquals(3, dataManager.getTemplates().size());
+        assertEquals("t1", dataManager.getTemplates().get(0).getName());
+        assertEquals("t2", dataManager.getTemplates().get(1).getName());
+        assertEquals("t3", dataManager.getTemplates().get(2).getName());
+    }
+
+    @Test
+    void setTemplates_withOrderSet_shouldRespectOrder() {
+        // GIVEN some templates with an explicit order set:
+        Template t1 = new Template();
+        t1.setName("t1");
+        t1.setOrder(999); // should come last!
+        t1.setSourceFile(new File(tempDir, "t1.template"));
+        Template t2 = new Template();
+        t2.setName("t2");
+        t2.setOrder(444); // should come first!
+        t2.setSourceFile(new File(tempDir, "t2.template"));
+        Template t3 = new Template();
+        t3.setName("t3");
+        t3.setOrder(555); // should come in the middle
+        t3.setSourceFile(new File(tempDir, "t3.template"));
+
+        // WHEN we set them in order by filename:
+        dataManager.setTemplates(List.of(t1, t2, t3));
+
+        // THEN they should be set according to their explicit order and ignore the filename:
+        assertEquals(3, dataManager.getTemplates().size());
+        assertEquals("t2", dataManager.getTemplates().get(0).getName());
+        assertEquals("t3", dataManager.getTemplates().get(1).getName());
+        assertEquals("t1", dataManager.getTemplates().get(2).getName());
+
+    }
+
+    @Test
+    void setQueries_withNoOrderSet_shouldOrderByName() {
+        // GIVEN some queries with no order set:
+        Query q1 = new Query();
+        q1.setName("q1");
+        q1.setSourceFile(new File(tempDir, "q1.query"));
+        Query q2 = new Query();
+        q2.setName("q2");
+        q2.setSourceFile(new File(tempDir, "q2.query"));
+        Query q3 = new Query();
+        q3.setName("q3");
+        q3.setSourceFile(new File(tempDir, "q3.query"));
+
+        // WHEN we set them in a random order:
+        dataManager.setQueries(List.of(q2, q3, q1));
+
+        // THEN they should be set according to the tiebreaker sort, which is source file name:
+        assertEquals(3, dataManager.getQueries().size());
+        assertEquals("q1", dataManager.getQueries().get(0).getName());
+        assertEquals("q2", dataManager.getQueries().get(1).getName());
+        assertEquals("q3", dataManager.getQueries().get(2).getName());
+    }
+
+    @Test
+    void setQueries_withOrderSet_shouldRespectOrder() {
+        // GIVEN some queries with an explicit order set:
+        Query q1 = new Query();
+        q1.setName("q1");
+        q1.setOrder(999); // should come last!
+        q1.setSourceFile(new File(tempDir, "q1.query"));
+        Query q2 = new Query();
+        q2.setName("q2");
+        q2.setOrder(444); // should come first!
+        q2.setSourceFile(new File(tempDir, "q2.query"));
+        Query q3 = new Query();
+        q3.setName("q3");
+        q3.setOrder(555); // should come in the middle
+        q3.setSourceFile(new File(tempDir, "q3.query"));
+
+        // WHEN we set them in order by name:
+        dataManager.setQueries(List.of(q1, q2, q3));
+
+        // THEN they should be set according to their explicit order and ignore the name:
+        assertEquals(3, dataManager.getQueries().size());
+        assertEquals("q2", dataManager.getQueries().get(0).getName());
+        assertEquals("q3", dataManager.getQueries().get(1).getName());
+        assertEquals("q1", dataManager.getQueries().get(2).getName());
     }
 }

--- a/src/test/java/ca/corbett/snotes/io/DataManagerTest.java
+++ b/src/test/java/ca/corbett/snotes/io/DataManagerTest.java
@@ -810,7 +810,7 @@ class DataManagerTest {
     }
 
     @Test
-    void setTemplates_withNoOrderSet_shouldOrderByFilename() {
+    void setTemplates_withNoOrderSet_shouldOrderBySourceFileName() {
         // GIVEN some templates with no order set:
         Template t1 = new Template();
         t1.setName("t1");
@@ -860,7 +860,7 @@ class DataManagerTest {
     }
 
     @Test
-    void setQueries_withNoOrderSet_shouldOrderByName() {
+    void setQueries_withNoOrderSet_shouldOrderBySourceFileName() {
         // GIVEN some queries with no order set:
         Query q1 = new Query();
         q1.setName("q1");

--- a/src/test/java/ca/corbett/snotes/io/SnotesIOTest.java
+++ b/src/test/java/ca/corbett/snotes/io/SnotesIOTest.java
@@ -746,4 +746,56 @@ class SnotesIOTest {
         String expectedName = FileSystemUtil.sanitizeFilename("My Test Template.template");
         assertEquals(expectedName, computed.getName());
     }
+
+    @Test
+    public void loadQuery_withNoOrderPresent_shouldDefaultOrderToZero() {
+        // GIVEN a Query saved in a file that has no "order" field at all:
+        File file = new File(tempDir, "no-order.query");
+        String content = "{\"name\":\"Test Query\",\"filters\":[]}";
+        try {
+            Files.writeString(file.toPath(), content, StandardCharsets.UTF_8);
+        }
+        catch (IOException ioe) {
+            fail("IOException thrown while setting up test file: " + ioe.getMessage());
+        }
+
+        // WHEN we load this Query:
+        Query loaded = null;
+        try {
+            loaded = SnotesIO.loadQuery(file);
+        }
+        catch (IOException ioe) {
+            fail("IOException thrown during load: " + ioe.getMessage());
+        }
+
+        // THEN it should have a default ordering of 0:
+        assertNotNull(loaded);
+        assertEquals(0, loaded.getOrder());
+    }
+
+    @Test
+    public void loadTemplate_withNoOrderPresent_shouldDefaultOrderToZero() {
+        // GIVEN a Template saved in a file that has no "order" field at all:
+        File file = new File(tempDir, "no-order.template");
+        String content = "{\"name\":\"Test Template\",\"dateOption\":\"NONE\",\"context\":\"NONE\",\"tags\":[]}";
+        try {
+            Files.writeString(file.toPath(), content, StandardCharsets.UTF_8);
+        }
+        catch (IOException ioe) {
+            fail("IOException thrown while setting up test file: " + ioe.getMessage());
+        }
+
+        // WHEN we load this Template:
+        Template loaded = null;
+        try {
+            loaded = SnotesIO.loadTemplate(file);
+        }
+        catch (IOException ioe) {
+            fail("IOException thrown during load: " + ioe.getMessage());
+        }
+
+        // THEN it should have a default ordering of 0:
+        assertNotNull(loaded);
+        assertEquals(0, loaded.getOrder());
+    }
 }

--- a/src/test/java/ca/corbett/snotes/model/QueryTest.java
+++ b/src/test/java/ca/corbett/snotes/model/QueryTest.java
@@ -256,5 +256,14 @@ public class QueryTest extends FilterTest {
         // THEN an IllegalArgumentException should be thrown:
         assertThrows(IllegalArgumentException.class, () -> query.execute(unfilteredList, -1));
     }
+
+    @Test
+    public void constructor_shouldDefaultOrderToZero() {
+        // WHEN we construct a Query with the default constructor:
+        Query query = new Query();
+
+        // THEN the order should be set to zero:
+        assertEquals(0, query.getOrder());
+    }
 }
 

--- a/src/test/java/ca/corbett/snotes/model/TemplateTest.java
+++ b/src/test/java/ca/corbett/snotes/model/TemplateTest.java
@@ -232,6 +232,15 @@ public class TemplateTest {
         assertEquals("my_tag_value", template.getTagList().get(0).getTag());
     }
 
+    @Test
+    public void constructor_shouldDefaultOrderToZero() {
+        // WHEN we construct a Template:
+        Template template = new Template();
+
+        // THEN the order should default to zero:
+        assertEquals(0, template.getOrder());
+    }
+
     // -----------------------------------------------------------------------
     // clearTags tests
     // -----------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses issue #66 by allowing manual reordering of Queries and Templates.

- added a new `order` field to `Query` and `Template`
- added tolerant loading so that existing persisted queries and templates will default to 0
- added auto-sorting in `DataManager` so that Queries and Templates are sorted by `order` and then by their filename as a tiebreaker.
- Added list up/down actions on `ManageQueriesDialog` and `ManageTemplatesDialog`
- user can move selected item up or down via buttons on the list field
- user also has new keyboard shortcuts (ctrl+up and ctrl+down) to move the selected item
- decided against drag-and-drop, because the existing item move options seem sufficient to me
- when the dialog is closed, if the ordering has changed, reload the UI so that the action panel updates to reflect the new ordering

Closes #66 