### PR TITLE
Issue #65 - fix context view initial scroll position

### DIFF
--- a/src/main/java/ca/corbett/snotes/ui/MultiNoteViewer.java
+++ b/src/main/java/ca/corbett/snotes/ui/MultiNoteViewer.java
@@ -7,6 +7,7 @@ import ca.corbett.snotes.ui.actions.UIReloadAction;
 
 import javax.swing.JPanel;
 import javax.swing.JTextPane;
+import javax.swing.SwingUtilities;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
 import javax.swing.text.Style;
@@ -14,6 +15,7 @@ import javax.swing.text.StyleConstants;
 import javax.swing.text.StyleContext;
 import java.awt.BorderLayout;
 import java.awt.Font;
+import java.awt.Rectangle;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
@@ -72,6 +74,41 @@ public class MultiNoteViewer extends JPanel implements UIReloadable {
      */
     public void dispose() {
         UIReloadAction.getInstance().unregisterReloadable(this);
+    }
+
+    /**
+     * Scrolls this viewer to the top. This method must not be invoked until the
+     * MultiNoteViewer is fully initialized and visible (otherwise nothing happens).
+     */
+    public void scrollToTop() {
+        SwingUtilities.invokeLater(() -> {
+            textPane.setCaretPosition(0);
+            try {
+                Rectangle rect = textPane.modelToView2D(0).getBounds();
+                textPane.scrollRectToVisible(rect);
+            }
+            catch (BadLocationException e) {
+                // ignore - 0 is always valid
+            }
+        });
+    }
+
+    /**
+     * Scrolls this viewer to the bottom. This method must not be invoked until the
+     * MultiNoteViewer is fully initialized and visible (otherwise nothing happens).
+     */
+    public void scrollToBottom() {
+        SwingUtilities.invokeLater(() -> {
+            int length = textPane.getDocument().getLength();
+            textPane.setCaretPosition(length);
+            try {
+                Rectangle rect = textPane.modelToView2D(length).getBounds();
+                textPane.scrollRectToVisible(rect);
+            }
+            catch (BadLocationException e) {
+                // ignore - length is always valid
+            }
+        });
     }
 
     /**

--- a/src/main/java/ca/corbett/snotes/ui/WriterFrame.java
+++ b/src/main/java/ca/corbett/snotes/ui/WriterFrame.java
@@ -57,6 +57,7 @@ public class WriterFrame extends JInternalFrame implements UIReloadable {
     private ShortTextField tagField;
     private JTextPane textPane;
     private boolean isDirty;
+    private boolean hasScrolledToBottom;
     private final Timer autoSaveTimer;
 
     /**
@@ -101,6 +102,7 @@ public class WriterFrame extends JInternalFrame implements UIReloadable {
         setDefaultCloseOperation(JInternalFrame.DISPOSE_ON_CLOSE);
         setFrameIcon(Resources.getLogoIcon(16));
         this.addInternalFrameListener(new FrameCloseListener());
+        this.hasScrolledToBottom = false;
         initComponents();
         if (dataManager.isScratchNote(note)) {
             // For scratch notes, we want to auto-save every minute, so we set up a timer to do that.
@@ -341,6 +343,19 @@ public class WriterFrame extends JInternalFrame implements UIReloadable {
             tabPane.setTabHeaderVisible(false);
         }
         tabPane.setSelectedIndex(selectedTab);
+
+        if (contextViewer != null) {
+            // Listen for tab changes, and scroll to the bottom of the context viewer the first time
+            // it is selected. This is surprisingly difficult, and must be deferred until the component
+            // is actually visible, or it will fail to have any effect. Java Swing is tricky sometimes.
+            tabPane.addChangeListener(e -> {
+                if (!hasScrolledToBottom) {
+                    contextViewer.scrollToBottom();
+                    hasScrolledToBottom = true;
+                }
+            });
+        }
+
         return tabPane;
     }
 

--- a/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
@@ -3,6 +3,7 @@ Author: Steve Corbett
 
 Version 2.0 [TODO] rewrite
   #66 - Allow manual reordering of Queries and Templates
+  #65 - Fix context view initial scroll position
   #62 - Implement auto-restart when changing data dirs
   #59 - Add limit option on search dialog
   #56 - Wire up UpdateManager for dynamic extensions


### PR DESCRIPTION
This PR addresses issue #65 by ensuring the the "context" view in `WriterFrame` is scrolled to the very bottom on initial display. The list of context notes is ordered from least recent to most recent, with most recent at the bottom of the list. The most recent note is usually the most relevant one when writing a new note, so by default it should be the most visible.

Had to fight with Java Swing to make this work - trying to scroll a `JTextPane` that is not yet rendered is apparently impossible.

Closes #65 