### PR TITLE
Issue #69 - fix bug in computeFile for undated notes

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,5 +2,6 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="ClassCanBeRecord" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="ExtractMethodRecommender" enabled="false" level="WARNING" enabled_by_default="false" />
   </profile>
 </component>

--- a/src/main/java/ca/corbett/snotes/io/SnotesIO.java
+++ b/src/main/java/ca/corbett/snotes/io/SnotesIO.java
@@ -443,8 +443,16 @@ class SnotesIO {
             // If this note has a source file that's already in the
             // static directory, we'll just save back to that file
             // instead of computing a location:
-            if (note.getSourceFile() != null && isInStaticDir(dataDirectory, note.getSourceFile())) {
-                return note.getSourceFile();
+            if (note.getSourceFile() != null) {
+                if (isInStaticDir(dataDirectory, note.getSourceFile())) {
+                    return note.getSourceFile();
+                }
+                else {
+                    // This could happen legitimately if the user edited a dated note and removed the date.
+                    // It's worth logging a warning, as it's a bit unusual, and might not be intentional.
+                    log.warning("Undated note has a source file that is not in the static directory. " +
+                                    "Ignoring source file and computing new file in static directory.");
+                }
             }
 
             // Otherwise, it'll be a direct child of the static dir:

--- a/src/main/java/ca/corbett/snotes/io/SnotesIO.java
+++ b/src/main/java/ca/corbett/snotes/io/SnotesIO.java
@@ -413,6 +413,18 @@ class SnotesIO {
     }
 
     /**
+     * Returns true if the given file is located in the scratch directory.
+     */
+    static boolean isInScratchDir(File dataDirectory, File file) {
+        if (file == null) {
+            return false;
+        }
+
+        File scratchDir = new File(dataDirectory, DataManager.SCRATCH_DIR);
+        return file.getAbsolutePath().startsWith(scratchDir.getAbsolutePath() + File.separator);
+    }
+
+    /**
      * Automatically computes a suggested File for the given Note based
      * on its metadata, and based on the supplied data directory.
      *
@@ -448,10 +460,13 @@ class SnotesIO {
                     return note.getSourceFile();
                 }
                 else {
-                    // This could happen legitimately if the user edited a dated note and removed the date.
-                    // It's worth logging a warning, as it's a bit unusual, and might not be intentional.
-                    log.warning("Undated note has a source file that is not in the static directory. " +
-                                    "Ignoring source file and computing new file in static directory.");
+                    // If we're not saving a scratch note, something is fishy...
+                    if (!isInScratchDir(dataDirectory, note.getSourceFile())) {
+                        // This could happen legitimately if the user edited a dated note and removed the date.
+                        // It's worth logging a warning, as it's a bit unusual, and might not be intentional.
+                        log.warning("Undated note has a source file that is not in the static directory. " +
+                                        "Ignoring source file and computing new save location in static directory.");
+                    }
                 }
             }
 

--- a/src/main/java/ca/corbett/snotes/io/SnotesIO.java
+++ b/src/main/java/ca/corbett/snotes/io/SnotesIO.java
@@ -400,6 +400,19 @@ class SnotesIO {
     }
 
     /**
+     * Returns true if the given file is located in the static directory,
+     * which is where undated notes are stored by default.
+     */
+    static boolean isInStaticDir(File dataDirectory, File file) {
+        if (file == null) {
+            return false;
+        }
+
+        File staticDir = new File(dataDirectory, DataManager.STATIC_DIR);
+        return file.getAbsolutePath().startsWith(staticDir.getAbsolutePath() + File.separator);
+    }
+
+    /**
      * Automatically computes a suggested File for the given Note based
      * on its metadata, and based on the supplied data directory.
      *
@@ -424,8 +437,17 @@ class SnotesIO {
                 + File.separator + date.getDayStr();
         }
 
-        // Undated notes go into the static directory by default, but the UI allows this to be changed:
+        // Undated notes go into the static directory by default.
+        // One day the UI will allow this to be customized.
         else {
+            // If this note has a source file that's already in the
+            // static directory, we'll just save back to that file
+            // instead of computing a location:
+            if (note.getSourceFile() != null && isInStaticDir(dataDirectory, note.getSourceFile())) {
+                return note.getSourceFile();
+            }
+
+            // Otherwise, it'll be a direct child of the static dir:
             dirPath += File.separator + DataManager.STATIC_DIR;
         }
 

--- a/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
@@ -2,6 +2,7 @@ Snotes Release Notes
 Author: Steve Corbett
 
 Version 2.0 [TODO] rewrite
+  #69 - Fix bug in computeFile with static notes
   #66 - Allow manual reordering of Queries and Templates
   #65 - Fix context view initial scroll position
   #62 - Implement auto-restart when changing data dirs

--- a/src/test/java/ca/corbett/snotes/io/SnotesIOTest.java
+++ b/src/test/java/ca/corbett/snotes/io/SnotesIOTest.java
@@ -748,6 +748,58 @@ class SnotesIOTest {
     }
 
     @Test
+    public void computeFile_withNoSourceFile_shouldCompute() {
+        // GIVEN a Note with no source file:
+        Note note = new Note();
+        note.setText("hello");
+
+        // WHEN we compute a file for it:
+        File computed = SnotesIO.computeFile(tempDir, note);
+
+        // THEN it should be a direct child of the static directory with the default untagged filename:
+        File expectedDir = new File(tempDir, DataManager.STATIC_DIR);
+        String expectedName = "untagged_note.txt";
+        assertEquals(expectedDir.getAbsolutePath(), computed.getParentFile().getAbsolutePath());
+        assertEquals(expectedName, computed.getName());
+    }
+
+    @Test
+    public void computeFile_withSourceFileOutsideOfStaticDir_shouldCompute() {
+        // GIVEN a Note with a source file that is outside of the static directory:
+        Note note = new Note();
+        note.setText("hello");
+        File externalFile = new File(tempDir, "external_note.snote");
+        note.setSourceFile(externalFile);
+
+        // WHEN we compute a file for it:
+        File computed = SnotesIO.computeFile(tempDir, note);
+
+        // THEN it should ignore the source file and compute as if there were no source file:
+        File expectedDir = new File(tempDir, DataManager.STATIC_DIR);
+        String expectedName = "untagged_note.txt";
+        assertEquals(expectedDir.getAbsolutePath(), computed.getParentFile().getAbsolutePath());
+        assertEquals(expectedName, computed.getName());
+    }
+
+    @Test
+    public void computeFile_withSourceFileInStaticDir_shouldSaveToSourceFile() {
+        // GIVEN a Note with a source file that is already inside the static directory:
+        //  (A valid real-world scenario! Undated notes can live anywhere in the static dir.)
+        File staticDir = new File(tempDir, DataManager.STATIC_DIR);
+        File subDir = new File(staticDir, "someSubDirectory");
+        File sourceFile = new File(subDir, "existing_note.snote");
+        Note note = new Note();
+        note.setText("hello");
+        note.setSourceFile(sourceFile);
+
+        // WHEN we compute a file for it:
+        File computed = SnotesIO.computeFile(tempDir, note);
+
+        // THEN it should return the existing source file rather than computing a new one:
+        assertEquals(sourceFile.getAbsolutePath(), computed.getAbsolutePath());
+    }
+
+    @Test
     public void loadQuery_withNoOrderPresent_shouldDefaultOrderToZero() {
         // GIVEN a Query saved in a file that has no "order" field at all:
         File file = new File(tempDir, "no-order.query");


### PR DESCRIPTION
This PR addresses issue #69 by improving the logic in `SnotesIO.computeFile()` when computing a save location for an undated note. If the note was loaded from any location in the `static` directory, then we want to just save back to that location, instead of computing a new location. 

Added a warning when saving an undated note with a non-null source file that is NOT already inside the static directory, as that might indicate a problem.

Closes #69 