### PR TITLE
Final touches for v2 release!

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ allowing for effortless searching.
 If you are running on Linux, and have Java 17 or higher installed, you can download the installer tarball:
 
 - [Snotes Installer](https://www.corbett.ca/apps/Snotes-2.0.tar.gz)
-- Size: TODO
-- Sha256: `TODO`
+- Size: 6MB
+- Sha256: `87e0eb8b4d1326f19b887baad9faef0a2e271adf2710caff0bb9dfb962edeee6`
 
 This is the best option, as you get an installer script that sets everything up for you:
 

--- a/installer.props
+++ b/installer.props
@@ -8,7 +8,7 @@ FORMAT="tarball"
 
 # Application name/version will also be used for the jar file name.
 APPLICATION="Snotes"
-VERSION="2.0-SNAPSHOT"
+VERSION="2.0"
 
 CATEGORY="TextEditor"
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ca.corbett</groupId>
     <artifactId>snotes</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.0</version>
 
     <name>snotes</name>
     <description>Snotes - Steve's Notes</description>

--- a/src/main/java/ca/corbett/snotes/Version.java
+++ b/src/main/java/ca/corbett/snotes/Version.java
@@ -8,7 +8,7 @@ public final class Version {
 
     private static final AboutInfo aboutInfo;
 
-    public static String NAME = "Snotes2"; // TODO name changed to Snotes2 to avoid conflict with V1 settings... change back when V2 is stable
+    public static String NAME = "Snotes";
     public static String VERSION = "2.0";
     public static String FULL_NAME = NAME + " " + VERSION;
     public static String COPYRIGHT = "Copyright © 2023-2026 Steve Corbett";
@@ -57,7 +57,7 @@ public final class Version {
     static {
         aboutInfo = new AboutInfo();
         aboutInfo.applicationName = NAME;
-        aboutInfo.applicationVersion = VERSION + "-SNAPSHOT"; // TODO remove this before release
+        aboutInfo.applicationVersion = VERSION;
         aboutInfo.copyright = COPYRIGHT;
         aboutInfo.license = LICENSE;
         aboutInfo.projectUrl = PROJECT_URL;

--- a/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
@@ -1,36 +1,37 @@
 Snotes Release Notes
 Author: Steve Corbett
 
-Version 2.0 [TODO] rewrite
-  #69 - Fix bug in computeFile with static notes
-  #66 - Allow manual reordering of Queries and Templates
-  #65 - Fix context view initial scroll position
-  #62 - Implement auto-restart when changing data dirs
-  #59 - Add limit option on search dialog
-  #56 - Wire up UpdateManager for dynamic extensions
-  #55 - Better progress display on initial load
-  #52 - Better options for discarding scratch notes
-  #50 - Fix bug regarding scratch file cleanup
-  #45 - WriterFrame: show optional context
-  #44 - Include update_sources.json for dynamic extensions
-  #42 - Add save prompt when exiting application
-  #40 - Implement WriterFrame, add collision handling
-  #37 - Read-only multi-Note viewer
-  #35 - Template builder: add warning for blank template
-  #33 - Implement UI for Template CRUD
-  #31 - Add "remember size and position" option
-  #30 - Implement the new search dialog
-  #28 - Implement UI for deleting Queries
-  #27 - Implement UI for editing Queries
-  #24 - Implement custom color themes
-  #21 - Implement UI for creating Queries
-  #20 - Implement intelligent model object persistence
-  #18 - Implement Template and basic persistence
-  #16 - Implement KeyStrokeManager
-  #14 - Implement ActionPanel (replaces JxTaskPane from V1)
-  #12 - Query persistence
-  #10 - Add support for statistics extension
+Version 2.0 [2026-04-03] - Complete rewrite!
   Port to GitHub, switch to Maven, upgrade to Java 17
+  Migrate from swing-extras 1.7 to 2.8; huge changes!
+  #10 - Add support for statistics extension
+  #12 - Query persistence
+  #14 - Implement ActionPanel (replaces JxTaskPane from V1)
+  #16 - Implement KeyStrokeManager
+  #18 - Implement Template and basic persistence
+  #20 - Implement intelligent model object persistence
+  #21 - Implement UI for creating Queries
+  #24 - Implement custom color themes
+  #27 - Implement UI for editing Queries
+  #28 - Implement UI for deleting Queries
+  #30 - Implement the new search dialog
+  #31 - Add "remember size and position" option
+  #33 - Implement UI for Template CRUD
+  #35 - Template builder: add warning for blank template
+  #37 - Read-only multi-Note viewer
+  #40 - Implement WriterFrame, add collision handling
+  #42 - Add save prompt when exiting application
+  #44 - Include update_sources.json for dynamic extensions
+  #45 - WriterFrame: show optional context
+  #50 - Fix bug regarding scratch file cleanup
+  #52 - Better options for discarding scratch notes
+  #55 - Better progress display on initial load
+  #56 - Wire up UpdateManager for dynamic extensions
+  #59 - Add limit option on search dialog
+  #62 - Implement auto-restart when changing data dirs
+  #65 - Fix context view initial scroll position
+  #66 - Allow manual reordering of Queries and Templates
+  #69 - Fix bug in computeFile with static notes
 
 Version 1.0 [2023-04-06]
   [SNOTES-1] - Skeletal project creation


### PR DESCRIPTION
This PR adds the final touches for the V2 release:

- adjust all version properties to remove `SNAPSHOT`
- add download information (size and sha256 sum) for installer tarball
- re-order release notes for V2 to match the oldest-to-newest style that V1 used
- changed application name from `Snotes2` to `Snotes` (the direct side-effect of this is that the application settings dir will be changed from `.Snotes2` to `.Snotes`. Upgrading from V1 to V2 will be a smoother experience. Downgrading back to V1 is still possible via the existing uninstall script.)