### PR TITLE
Changes for v2.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you are running on Linux, and have Java 17 or higher installed, you can downl
 
 - [Snotes Installer](https://www.corbett.ca/apps/Snotes-2.1.tar.gz)
 - Size: 6MB
-- Sha256: `33785dabd178f220238542a6d952f0175314e7edf7df6f512f47d7021f349eed`
+- Sha256: `bf16960fc8d3e45e46e802b04e994669124a2976e75819f0ff680e19d87685d5`
 
 This is the best option, as you get an installer script that sets everything up for you:
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ allowing for effortless searching.
 If you are running on Linux, and have Java 17 or higher installed, you can download the installer tarball:
 
 - [Snotes Installer](https://www.corbett.ca/apps/Snotes-2.1.tar.gz)
-- Size: TODO
-- Sha256: `TODO`
+- Size: 6MB
+- Sha256: `33785dabd178f220238542a6d952f0175314e7edf7df6f512f47d7021f349eed`
 
 This is the best option, as you get an installer script that sets everything up for you:
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ allowing for effortless searching.
 
 If you are running on Linux, and have Java 17 or higher installed, you can download the installer tarball:
 
-- [Snotes Installer](https://www.corbett.ca/apps/Snotes-2.0.tar.gz)
-- Size: 6MB
-- Sha256: `87e0eb8b4d1326f19b887baad9faef0a2e271adf2710caff0bb9dfb962edeee6`
+- [Snotes Installer](https://www.corbett.ca/apps/Snotes-2.1.tar.gz)
+- Size: TODO
+- Sha256: `TODO`
 
 This is the best option, as you get an installer script that sets everything up for you:
 
@@ -36,7 +36,7 @@ mvn clean package
 
 # Run the executable jar that Maven created:
 cd target
-java -jar snotes-2.0.jar
+java -jar snotes-2.1.jar
 ```
 
 ## User guide

--- a/installer.props
+++ b/installer.props
@@ -8,7 +8,7 @@ FORMAT="tarball"
 
 # Application name/version will also be used for the jar file name.
 APPLICATION="Snotes"
-VERSION="2.0"
+VERSION="2.1"
 
 CATEGORY="TextEditor"
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ca.corbett</groupId>
     <artifactId>snotes</artifactId>
-    <version>2.0</version>
+    <version>2.1</version>
 
     <name>snotes</name>
     <description>Snotes - Steve's Notes</description>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>ca.corbett</groupId>
             <artifactId>swing-extras</artifactId>
-            <version>2.8.0</version>
+            <version>2.9.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/ca/corbett/snotes/Main.java
+++ b/src/main/java/ca/corbett/snotes/Main.java
@@ -1,5 +1,6 @@
 package ca.corbett.snotes;
 
+import ca.corbett.extras.FallbackExceptionHandler;
 import ca.corbett.extras.LookAndFeelManager;
 import ca.corbett.extras.SingleInstanceManager;
 import ca.corbett.snotes.extensions.SnotesExtensionManager;
@@ -46,6 +47,10 @@ public class Main {
     public static void main(String[] args) {
         // Before we do anything else, set up logging:
         configureLogging();
+
+        // Register a fallback exception handler for uncaught exceptions.
+        // This ensures they will at least get logged with a proper stack trace.
+        FallbackExceptionHandler.register();
 
         // Ensure only a single instance is running (if configured to do so):
         boolean isSingleInstanceEnabled = Boolean.parseBoolean(AppConfig.peek(AppConfig.SINGLE_INSTANCE_PROP));

--- a/src/main/java/ca/corbett/snotes/Version.java
+++ b/src/main/java/ca/corbett/snotes/Version.java
@@ -8,12 +8,12 @@ public final class Version {
 
     private static final AboutInfo aboutInfo;
 
-    public static String NAME = "Snotes";
-    public static String VERSION = "2.0";
-    public static String FULL_NAME = NAME + " " + VERSION;
-    public static String COPYRIGHT = "Copyright © 2023-2026 Steve Corbett";
-    public static String PROJECT_URL = "https://github.com/scorbo2/snotes";
-    public static String LICENSE = "https://opensource.org/license/mit";
+    public static final String NAME = "Snotes";
+    public static final String VERSION = "2.1";
+    public static final String FULL_NAME = NAME + " " + VERSION;
+    public static final String COPYRIGHT = "Copyright © 2023-2026 Steve Corbett";
+    public static final String PROJECT_URL = "https://github.com/scorbo2/snotes";
+    public static final String LICENSE = "https://opensource.org/license/mit";
 
     /**
      * The directory where the application was installed -

--- a/src/main/java/ca/corbett/snotes/io/DataManager.java
+++ b/src/main/java/ca/corbett/snotes/io/DataManager.java
@@ -75,10 +75,10 @@ public class DataManager {
     private final List<Note> scratchNotes;
     private final AtomicInteger loadProgress;
 
-    private final File dataDir;
-    private final File metadataDir;
-    private final File staticDir;
-    private final File scratchDir;
+    private File dataDir;
+    private File metadataDir;
+    private File staticDir;
+    private File scratchDir;
 
     /**
      * Creates a new DataManager with empty caches and a data directory
@@ -579,6 +579,20 @@ public class DataManager {
                 saveTemplate(template);
             }
         }
+    }
+
+    /**
+     * Attempts a saveAll() of all current data, then discards all cached in-memory data
+     * and switches to the given data directory.
+     */
+    public void switchDataDirectory(File dataDir, LoadListener listener) throws IOException {
+        saveAll();
+        this.dataDir = dataDir;
+        // These directories may not exist, but that's okay... loadAll() will deal with it:
+        metadataDir = new File(dataDir, METADATA_DIR);
+        staticDir = new File(dataDir, STATIC_DIR);
+        scratchDir = new File(dataDir, SCRATCH_DIR);
+        loadAll(listener);
     }
 
     /**

--- a/src/main/java/ca/corbett/snotes/ui/MainWindow.java
+++ b/src/main/java/ca/corbett/snotes/ui/MainWindow.java
@@ -205,6 +205,25 @@ public class MainWindow extends JFrame implements UIReloadable {
         }
     }
 
+    /**
+     * Closes all open frames. This may trigger save prompt dialogs if any frame has unsaved changes.
+     * You can invoke saveAll() before invoking this if you just want to close everything silently.
+     */
+    public void closeAll() {
+        // Go through all internal frames and dispose them.
+        // If any of them (like WriterFrame) have a save prompt on close,
+        // this will trigger that, giving the user a chance to save their work before we exit.
+        for (JInternalFrame frame : desktopPane.getAllFrames()) {
+            try {
+                frame.toFront();
+                frame.setClosed(true); // don't call dispose()! It bypasses the frame close listener.
+            }
+            catch (PropertyVetoException ignored) {
+                // Just ignore it
+            }
+        }
+    }
+
     private void initComponents() {
         desktopPane = new CustomizableDesktopPane(Resources.getLogoWide(),
                                                   AppConfig.getInstance().getDesktopLogoPlacement(),
@@ -228,18 +247,7 @@ public class MainWindow extends JFrame implements UIReloadable {
         }
         cleanupComplete = true;
 
-        // Go through all internal frames and dispose them.
-        // If any of them (like WriterFrame) have a save prompt on close,
-        // this will trigger that, giving the user a chance to save their work before we exit.
-        for (JInternalFrame frame : desktopPane.getAllFrames()) {
-            try {
-                frame.toFront();
-                frame.setClosed(true); // don't call dispose()! It bypasses the frame close listener.
-            }
-            catch (PropertyVetoException ignored) {
-                // Just ignore it - application exit can't be canceled at this point
-            }
-        }
+        closeAll();
 
         // Always save window state, even if "remember state" is disabled:
         AppConfig.getInstance().setWindowProps(getExtendedState(), getWidth(), getHeight(), getX(), getY());
@@ -250,6 +258,14 @@ public class MainWindow extends JFrame implements UIReloadable {
         keyStrokeManager.dispose();
         SnotesExtensionManager.getInstance().deactivateAll();
         SingleInstanceManager.getInstance().release();
+    }
+
+    /**
+     * Resets our "initial load" flag, so we will do our initial load behavior again
+     * the next time reloadUI() is invoked. This is handy when switching to a new data directory.
+     */
+    public void resetInitialLoad() {
+        initialLoad = true;
     }
 
     /**

--- a/src/main/java/ca/corbett/snotes/ui/WriterFrame.java
+++ b/src/main/java/ca/corbett/snotes/ui/WriterFrame.java
@@ -215,8 +215,14 @@ public class WriterFrame extends JInternalFrame implements UIReloadable {
         if (!headerForm.isFormValid()) {
             return false; // Validation errors will show on the form (invalid date or missing tags).
         }
-        if (!isDirty) {
-            return true; // counts as successful save, since there are no changes to save!
+
+        // Scratch notes get auto-saved on a timer, which will mark them as no longer dirty,
+        // even though they have not yet been properly saved. So, if this is a scratch note,
+        // we want to skip the isDirty check and allow the save to proceed, otherwise an
+        // early return here might prevent the save from happening. Non-scratch notes have no
+        // auto-save timer, so it's safe to return here if they are not dirty.
+        if (!isDirty && !dataManager.isScratchNote(note)) {
+            return true;
         }
 
         note.clearAllTags(); // we will nuke and pave to overwrite old settings

--- a/src/main/java/ca/corbett/snotes/ui/actions/PrefsAction.java
+++ b/src/main/java/ca/corbett/snotes/ui/actions/PrefsAction.java
@@ -4,10 +4,10 @@ import ca.corbett.extras.EnhancedAction;
 import ca.corbett.extras.MessageUtil;
 import ca.corbett.snotes.AppConfig;
 import ca.corbett.snotes.ui.MainWindow;
-import ca.corbett.updates.UpdateManager;
 
 import java.awt.event.ActionEvent;
 import java.io.File;
+import java.io.IOException;
 import java.util.logging.Logger;
 
 /**
@@ -33,18 +33,21 @@ public class PrefsAction extends EnhancedAction {
             // If the data directory changed, we need to restart the application:
             File newDataDirectory = AppConfig.getInstance().getDataDirectory();
             if (!dataDirectory.getAbsolutePath().equals(newDataDirectory.getAbsolutePath())) {
+                MainWindow.getInstance().saveAll(); // save everything first!
+                MainWindow.getInstance().closeAll();
+                try {
+                    // Purge in-memory cache, switch to the new data directory, and reload the UI.
+                    MainWindow.getInstance().getDataManager().switchDataDirectory(newDataDirectory, l -> {
+                        MainWindow.getInstance().resetInitialLoad();
+                        UIReloadAction.getInstance().actionPerformed(null);
+                    });
 
-                // We can restart automatically, if an UpdateManager is configured:
-                UpdateManager updateManager = MainWindow.getInstance().getUpdateManager();
-                if (updateManager != null) {
-                    // Will restart if user confirms:
-                    updateManager.showApplicationRestartPrompt(MainWindow.getInstance());
+                    // Avoid multiple UI reloads:
+                    return;
                 }
-
-                // Otherwise, all we can do is nag the user to do it for us:
-                else {
-                    getMessageUtil().info("Restart required",
-                                          "Changing the data directory requires restarting the application.");
+                catch (IOException ioe) {
+                    log.severe("Failed to switch data directory: " + ioe.getMessage());
+                    getMessageUtil().error("Failed to switch data directory: " + ioe.getMessage(), ioe);
                 }
             }
 

--- a/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
@@ -1,6 +1,12 @@
 Snotes Release Notes
 Author: Steve Corbett
 
+Version 2.1 [TODO] - Maintenance release
+  Upgrade to swing-extras 2.9 (minor upgrade)
+  #77 - add fallback exception handler
+  #76 - fix auto-save bug in WriterFrame
+  #73 - minor code cleanup
+
 Version 2.0 [2026-04-03] - Complete rewrite!
   Port to GitHub, switch to Maven, upgrade to Java 17
   Migrate from swing-extras 1.7 to 2.8; huge changes!

--- a/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
@@ -5,6 +5,7 @@ Version 2.1 [TODO] - Maintenance release
   Upgrade to swing-extras 2.9 (minor upgrade)
   #77 - add fallback exception handler
   #76 - fix auto-save bug in WriterFrame
+  #75 - don't force an app restart when changing data dirs
   #73 - minor code cleanup
 
 Version 2.0 [2026-04-03] - Complete rewrite!

--- a/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
@@ -1,7 +1,7 @@
 Snotes Release Notes
 Author: Steve Corbett
 
-Version 2.1 [TODO] - Maintenance release
+Version 2.1 [2026-04-29] - Maintenance release
   Upgrade to swing-extras 2.9 (minor upgrade)
   #77 - add fallback exception handler
   #76 - fix auto-save bug in WriterFrame


### PR DESCRIPTION
This PR contains all changes for the `v2.1` release of the application:

- Upgrade to swing-extras 2.9 (minor release)
- Closes #73 - make version constants final
- Closes #75 - don't force application restart just to change data directories
- Closes #76 - fix bug related to auto-save in `WriterFrame`
- Closes #77 - make use of `FallbackExceptionHandler` from swing-extras 2.9
