### PR TITLE
Issue #87 - handle changes required by swing-extras 3.0 upgrade

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_25" default="true" project-jdk-name="temurin-25" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ allowing for effortless searching.
 
 ### Option 1: Installer tarball
 
-If you are running on Linux, and have Java 17 or higher installed, you can download the installer tarball:
+If you are running on Linux, and have Java 25 or higher installed, you can download the installer tarball:
 
 - [Snotes Installer](https://www.corbett.ca/apps/Snotes-2.1.tar.gz)
 - Size: 6MB

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
     </scm>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
For issue #87 - surprisingly, the only thing that broke after upgrading to swing-extras 3.0 was the java upgrade (17 to 25). 