### PR TITLE
Issue #79 - fix unit tests on windows

### DIFF
--- a/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
@@ -2,7 +2,9 @@ Snotes Release Notes
 Author: Steve Corbett
 
 Version 2.2 [TODO release date]
+  #87 - upgrade to Java 25 / swing-extras 3.0
   #83 - add right-click context menu in editor pane
+  #79 - fix unit tests on Windows
 
 Version 2.1 [2026-04-29] - Maintenance release
   Upgrade to swing-extras 2.9 (minor upgrade)

--- a/src/test/java/ca/corbett/snotes/io/SnotesIOTest.java
+++ b/src/test/java/ca/corbett/snotes/io/SnotesIOTest.java
@@ -658,10 +658,11 @@ class SnotesIOTest {
         assertEquals("untagged_note.txt", computed.getName());
 
         // AND it should be in a dated subdirectory structure in the data directory:
-        String expectedPath = tempDir.getAbsolutePath() + File.separator
-            + note.getDate().getYearStr() + File.separator
+        File expectedDir = new File(tempDir,
+            note.getDate().getYearStr() + File.separator
             + note.getDate().getMonthStr() + File.separator
-            + note.getDate().getDayStr() + File.separator + "untagged_note.txt";
+            + note.getDate().getDayStr());
+        String expectedPath = new File(expectedDir, "untagged_note.txt").getAbsolutePath();
         assertEquals(expectedPath, computed.getAbsolutePath());
     }
 
@@ -684,10 +685,11 @@ class SnotesIOTest {
         assertEquals("project_work.txt", computed.getName());
 
         // AND it should be in a dated subdirectory structure in the data directory:
-        String expectedPath = tempDir.getAbsolutePath() + File.separator
-            + note.getDate().getYearStr() + File.separator
+        File expectedDir = new File(tempDir,
+            note.getDate().getYearStr() + File.separator
             + note.getDate().getMonthStr() + File.separator
-            + note.getDate().getDayStr() + File.separator + "project_work.txt";
+            + note.getDate().getDayStr());
+        String expectedPath = new File(expectedDir, "project_work.txt").getAbsolutePath();
         assertEquals(expectedPath, computed.getAbsolutePath());
     }
 

--- a/src/test/java/ca/corbett/snotes/model/NoteTest.java
+++ b/src/test/java/ca/corbett/snotes/model/NoteTest.java
@@ -3,6 +3,7 @@ package ca.corbett.snotes.model;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -104,7 +105,7 @@ class NoteTest {
         String relativePath = Note.getRelativePath(note, dataDir);
 
         // THEN it should return the correct relative path:
-        assertEquals("notes/note1.txt", relativePath);
+        assertEquals(Paths.get("notes", "note1.txt").toString(), relativePath);
     }
 
     @Test
@@ -118,6 +119,11 @@ class NoteTest {
         String relativePath = Note.getRelativePath(note, dataDir);
 
         // THEN it should return the absolute path of the source file:
-        assertEquals("/other/path/note1.txt", relativePath);
+        assertEquals(new File("/other/path/note1.txt")
+                         .toPath()
+                         .toAbsolutePath()
+                         .normalize()
+                         .toString(),
+                     relativePath);
     }
 }


### PR DESCRIPTION
This PR addresses issue #79 by fixing a few unit tests that were failing when run on a Windows machine. Test changes only - no functional changes in this PR.

Also added a release note that was missed for an unrelated issue.