### PR TITLE
Issue #92 - add font size quick change option

### DIFF
--- a/src/main/java/ca/corbett/snotes/AppConfig.java
+++ b/src/main/java/ca/corbett/snotes/AppConfig.java
@@ -31,6 +31,7 @@ import ca.corbett.snotes.ui.EditorTheme;
 import ca.corbett.snotes.ui.actions.AboutAction;
 import ca.corbett.snotes.ui.actions.ExitAction;
 import ca.corbett.snotes.ui.actions.ExtensionManagerAction;
+import ca.corbett.snotes.ui.actions.FontSizeQuickChangeAction;
 import ca.corbett.snotes.ui.actions.LogConsoleAction;
 import ca.corbett.snotes.ui.actions.NewNoteAction;
 import ca.corbett.snotes.ui.actions.PrefsAction;
@@ -100,6 +101,8 @@ public class AppConfig extends AppProperties<SnotesExtension> {
     public static final String KEY_PREFERENCES = KEYSTROKE_PREFIX + "General.preferences";
     public static final String KEY_SEARCH = KEYSTROKE_PREFIX + "General.search";
     public static final String KEY_EXIT = KEYSTROKE_PREFIX + "General.exit";
+    public static final String KEY_FONT_SIZE_UP = KEYSTROKE_PREFIX + "General.fontSizeUp";
+    public static final String KEY_FONT_SIZE_DOWN = KEYSTROKE_PREFIX + "General.fontSizeDown";
 
     // We centralize these here so that KeyStrokeManager can handle updating
     // their keyboard accelerators when the user changes them in the properties dialog:
@@ -111,6 +114,8 @@ public class AppConfig extends AppProperties<SnotesExtension> {
     private EnhancedAction preferencesAction;
     private EnhancedAction searchAction;
     private EnhancedAction exitAction;
+    private EnhancedAction fontSizeUpAction;
+    private EnhancedAction fontSizeDownAction;
 
     private BooleanProperty enableSingleInstance;
     private BooleanProperty rememberSizePositionProp;
@@ -298,12 +303,53 @@ public class AppConfig extends AppProperties<SnotesExtension> {
         return exitAction;
     }
 
+    public EnhancedAction getFontSizeUpAction() {
+        return fontSizeUpAction;
+    }
+
+    public EnhancedAction getFontSizeDownAction() {
+        return fontSizeDownAction;
+    }
+
     public Font getTagFont() {
         return tagFontProp.getFont();
     }
 
     public Font getNoteFont() {
         return noteFontProp.getFont();
+    }
+
+    /**
+     * Adjusts both tag and text font size by the given increment, and then triggers
+     * an immediate save() to persist the change immediately. Intended to be
+     * used by FontSizeQuickChangeAction.
+     * <p>
+     * We group the two font changes together so we only save() once.
+     * </p>
+     *
+     * @param increment a positive/negative point size by which we will increment or decrement the current sizes.
+     */
+    public void changeFontSizes(int increment) {
+        Font tagFont = getTagFont();
+        Font textFont = getNoteFont();
+
+        // If EITHER font size gets too small, we'll abort this change (even if the other font
+        // size could still be reduced!). This is so that we can maintain the "gap" between the
+        // two font sizes if the user makes them larger again.
+        if (increment < 0 && (tagFont.getSize() <= 2 || textFont.getSize() <= 2)) {
+            log.warning("Font size cannot be decreased any further.");
+            return;
+        }
+
+        // Note: we don't put an upper limit on font size.
+        // If the user wants to make their fonts huge, more power to them!
+
+        // Adjust and save:
+        Font newTagFont = new Font(tagFont.getName(), tagFont.getStyle(), tagFont.getSize() + increment);
+        Font newTextFont = new Font(textFont.getName(), textFont.getStyle(), textFont.getSize() + increment);
+        tagFontProp.setFont(newTagFont);
+        noteFontProp.setFont(newTextFont);
+        save(); // trigger an immediate save() to persist this.
     }
 
     /**
@@ -370,6 +416,8 @@ public class AppConfig extends AppProperties<SnotesExtension> {
         keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_PREFERENCES));
         keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_SEARCH));
         keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_EXIT));
+        keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_FONT_SIZE_UP));
+        keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_FONT_SIZE_DOWN));
 
         // And now ask our extension manager:
         keyProps.addAll(SnotesExtensionManager.getInstance().getKeyStrokeProperties());
@@ -554,6 +602,8 @@ public class AppConfig extends AppProperties<SnotesExtension> {
         preferencesAction = new PrefsAction();
         searchAction = new SearchAction();
         exitAction = new ExitAction();
+        fontSizeUpAction = new FontSizeQuickChangeAction(2);
+        fontSizeDownAction = new FontSizeQuickChangeAction(-2);
 
         List<AbstractProperty> props = new ArrayList<>();
 
@@ -580,6 +630,12 @@ public class AppConfig extends AppProperties<SnotesExtension> {
                       .setAllowBlank(true));
         props.add(new KeyStrokeProperty(KEY_EXIT, "Exit:",
                                         KeyStrokeManager.parseKeyStroke("Ctrl+Q"), exitAction)
+                      .setAllowBlank(true));
+        props.add(new KeyStrokeProperty(KEY_FONT_SIZE_UP, "Increase font size:",
+                                        KeyStrokeManager.parseKeyStroke("Ctrl+equals"), fontSizeUpAction)
+                      .setAllowBlank(true));
+        props.add(new KeyStrokeProperty(KEY_FONT_SIZE_DOWN, "Decrease font size:",
+                                        KeyStrokeManager.parseKeyStroke("Ctrl+minus"), fontSizeDownAction)
                       .setAllowBlank(true));
 
         return props;

--- a/src/main/java/ca/corbett/snotes/AppConfig.java
+++ b/src/main/java/ca/corbett/snotes/AppConfig.java
@@ -336,7 +336,7 @@ public class AppConfig extends AppProperties<SnotesExtension> {
         // If EITHER font size gets too small, we'll abort this change (even if the other font
         // size could still be reduced!). This is so that we can maintain the "gap" between the
         // two font sizes if the user makes them larger again.
-        if (increment < 0 && (tagFont.getSize() <= 2 || textFont.getSize() <= 2)) {
+        if (tagFont.getSize() + increment < 2 || textFont.getSize() + increment < 2) {
             log.warning("Font size cannot be decreased any further.");
             return;
         }

--- a/src/main/java/ca/corbett/snotes/ui/actions/FontSizeQuickChangeAction.java
+++ b/src/main/java/ca/corbett/snotes/ui/actions/FontSizeQuickChangeAction.java
@@ -1,0 +1,45 @@
+package ca.corbett.snotes.ui.actions;
+
+import ca.corbett.extras.EnhancedAction;
+import ca.corbett.snotes.AppConfig;
+
+import java.awt.event.ActionEvent;
+import java.util.logging.Logger;
+
+/**
+ * An action that can be used to quickly adjust the font size in all edit panes up or down.
+ * The idea was stolen from the CryptText application, but this is a slightly different implementation.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class FontSizeQuickChangeAction extends EnhancedAction {
+
+    private static final Logger log = Logger.getLogger(FontSizeQuickChangeAction.class.getName());
+
+    private final int increment;
+
+    public FontSizeQuickChangeAction(int increment) {
+        super(increment > 0 ? "Increase Font Size" : "Decrease Font Size");
+        this.increment = increment;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        // Handle the wonky case first:
+        if (increment == 0) {
+             log.warning("FontSizeQuickChangeAction created with increment of 0. This action will do nothing.");
+             return;
+        }
+
+        // There are two font sizes: the tag font and the text font.
+        // It would be nice to change them proportionally, as the tag font is usually just
+        // slightly larger than the text font, and that difference would grow as the
+        // font sizes increase. But for now, we will just change them both
+        // by the same fixed increment. The difference between them is small enough
+        // that this approach should be fine.
+        AppConfig.getInstance().changeFontSizes(increment);
+
+        // Trigger a UI reload to force all open edit panes to update their font sizes.
+        UIReloadAction.getInstance().actionPerformed(null);
+    }
+}

--- a/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
@@ -2,6 +2,7 @@ Snotes Release Notes
 Author: Steve Corbett
 
 Version 2.2 [TODO release date]
+  #92 - add global hotkeys for font size adjustment
   #87 - upgrade to Java 25 / swing-extras 3.0
   #83 - add right-click context menu in editor pane
   #79 - fix unit tests on Windows


### PR DESCRIPTION
This PR addresses issue #92 by adding a "quick change" option for adjusting font sizes in the editors without having to visit the application preferences dialog. This is very similar to what was done for the CryptText application: the user can hit global keyboard shortcuts (configurable) to quickly increment or decrement the font sizes. A properties save and a UI reload are immediately triggered so that the result is persisted and made visible right away.
