### PR TITLE
Issue 82 tag list

### DIFF
--- a/src/main/java/ca/corbett/snotes/AppConfig.java
+++ b/src/main/java/ca/corbett/snotes/AppConfig.java
@@ -37,6 +37,7 @@ import ca.corbett.snotes.ui.actions.NewNoteAction;
 import ca.corbett.snotes.ui.actions.PrefsAction;
 import ca.corbett.snotes.ui.actions.SaveAction;
 import ca.corbett.snotes.ui.actions.SearchAction;
+import ca.corbett.snotes.ui.actions.TagListAction;
 import com.formdev.flatlaf.FlatLightLaf;
 
 import java.awt.Color;
@@ -103,6 +104,7 @@ public class AppConfig extends AppProperties<SnotesExtension> {
     public static final String KEY_EXIT = KEYSTROKE_PREFIX + "General.exit";
     public static final String KEY_FONT_SIZE_UP = KEYSTROKE_PREFIX + "General.fontSizeUp";
     public static final String KEY_FONT_SIZE_DOWN = KEYSTROKE_PREFIX + "General.fontSizeDown";
+    public static final String KEY_TAG_LIST = KEYSTROKE_PREFIX + "General.tagList";
 
     // We centralize these here so that KeyStrokeManager can handle updating
     // their keyboard accelerators when the user changes them in the properties dialog:
@@ -116,6 +118,7 @@ public class AppConfig extends AppProperties<SnotesExtension> {
     private EnhancedAction exitAction;
     private EnhancedAction fontSizeUpAction;
     private EnhancedAction fontSizeDownAction;
+    private EnhancedAction tagListAction;
 
     private BooleanProperty enableSingleInstance;
     private BooleanProperty rememberSizePositionProp;
@@ -309,6 +312,10 @@ public class AppConfig extends AppProperties<SnotesExtension> {
 
     public EnhancedAction getFontSizeDownAction() {
         return fontSizeDownAction;
+    }
+
+    public EnhancedAction getTagListAction() {
+        return tagListAction;
     }
 
     public Font getTagFont() {
@@ -604,6 +611,7 @@ public class AppConfig extends AppProperties<SnotesExtension> {
         exitAction = new ExitAction();
         fontSizeUpAction = new FontSizeQuickChangeAction(2);
         fontSizeDownAction = new FontSizeQuickChangeAction(-2);
+        tagListAction = new TagListAction();
 
         List<AbstractProperty> props = new ArrayList<>();
 
@@ -636,6 +644,9 @@ public class AppConfig extends AppProperties<SnotesExtension> {
                       .setAllowBlank(true));
         props.add(new KeyStrokeProperty(KEY_FONT_SIZE_DOWN, "Decrease font size:",
                                         KeyStrokeManager.parseKeyStroke("Ctrl+minus"), fontSizeDownAction)
+                      .setAllowBlank(true));
+        props.add(new KeyStrokeProperty(KEY_TAG_LIST, "Show tag list:",
+                                        KeyStrokeManager.parseKeyStroke("Ctrl+T"), tagListAction)
                       .setAllowBlank(true));
 
         return props;

--- a/src/main/java/ca/corbett/snotes/AppConfig.java
+++ b/src/main/java/ca/corbett/snotes/AppConfig.java
@@ -425,6 +425,7 @@ public class AppConfig extends AppProperties<SnotesExtension> {
         keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_EXIT));
         keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_FONT_SIZE_UP));
         keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_FONT_SIZE_DOWN));
+        keyProps.add((KeyStrokeProperty)getPropertiesManager().getProperty(KEY_TAG_LIST));
 
         // And now ask our extension manager:
         keyProps.addAll(SnotesExtensionManager.getInstance().getKeyStrokeProperties());

--- a/src/main/java/ca/corbett/snotes/io/DataManager.java
+++ b/src/main/java/ca/corbett/snotes/io/DataManager.java
@@ -6,6 +6,7 @@ import ca.corbett.extras.progress.SimpleProgressAdapter;
 import ca.corbett.snotes.AppConfig;
 import ca.corbett.snotes.model.Note;
 import ca.corbett.snotes.model.Query;
+import ca.corbett.snotes.model.Tag;
 import ca.corbett.snotes.model.Template;
 import ca.corbett.snotes.ui.MainWindow;
 
@@ -538,6 +539,19 @@ public class DataManager {
             }
         }
         return new ArrayList<>(years);
+    }
+
+    /**
+     * Examines all notes in cache (regular notes only - no scratch notes), and returns a list of all unique
+     * non-date tags used across all notes. The returned list is sorted alphabetically and
+     * contains no duplicates. The returned list may be empty if no notes have any tags.
+     */
+    public List<Tag> getUniqueTags() {
+        SortedSet<Tag> uniqueTags = new TreeSet<>();
+        for (Note note : notes) {
+            uniqueTags.addAll(note.getNonDateTags());
+        }
+        return new ArrayList<>(uniqueTags);
     }
 
     /**

--- a/src/main/java/ca/corbett/snotes/io/DataManager.java
+++ b/src/main/java/ca/corbett/snotes/io/DataManager.java
@@ -7,6 +7,7 @@ import ca.corbett.snotes.AppConfig;
 import ca.corbett.snotes.model.Note;
 import ca.corbett.snotes.model.Query;
 import ca.corbett.snotes.model.Tag;
+import ca.corbett.snotes.model.TagUsage;
 import ca.corbett.snotes.model.Template;
 import ca.corbett.snotes.ui.MainWindow;
 
@@ -17,7 +18,9 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.SortedSet;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -543,15 +546,22 @@ public class DataManager {
 
     /**
      * Examines all notes in cache (regular notes only - no scratch notes), and returns a list of all unique
-     * non-date tags used across all notes. The returned list is sorted alphabetically and
-     * contains no duplicates. The returned list may be empty if no notes have any tags.
+     * non-date tags used across all notes, along with the count of notes that use each tag.
+     * The returned list is sorted alphabetically by tag name. The returned list may be empty
+     * if no notes have any tags.
      */
-    public List<Tag> getUniqueTags() {
-        SortedSet<Tag> uniqueTags = new TreeSet<>();
+    public List<TagUsage> getUniqueTags() {
+        Map<Tag, Integer> tagCounts = new TreeMap<>();
         for (Note note : notes) {
-            uniqueTags.addAll(note.getNonDateTags());
+            for (Tag tag : note.getNonDateTags()) {
+                tagCounts.merge(tag, 1, Integer::sum);
+            }
         }
-        return new ArrayList<>(uniqueTags);
+        List<TagUsage> result = new ArrayList<>();
+        for (Map.Entry<Tag, Integer> entry : tagCounts.entrySet()) {
+            result.add(new TagUsage(entry.getKey(), entry.getValue()));
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/ca/corbett/snotes/model/TagUsage.java
+++ b/src/main/java/ca/corbett/snotes/model/TagUsage.java
@@ -1,0 +1,12 @@
+package ca.corbett.snotes.model;
+
+/**
+ * Represents a tag along with the number of non-scratch notes that use it.
+ * Used by {@link ca.corbett.snotes.io.DataManager#getUniqueTags()} to provide
+ * tag usage statistics for the TagListDialog.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since Snotes 2.2
+ */
+public record TagUsage(Tag tag, int count) {
+}

--- a/src/main/java/ca/corbett/snotes/ui/TagListDialog.java
+++ b/src/main/java/ca/corbett/snotes/ui/TagListDialog.java
@@ -1,0 +1,115 @@
+package ca.corbett.snotes.ui;
+
+import ca.corbett.extras.MessageUtil;
+import ca.corbett.extras.ScrollUtil;
+import ca.corbett.snotes.io.DataManager;
+import ca.corbett.snotes.model.Note;
+import ca.corbett.snotes.model.Query;
+import ca.corbett.snotes.model.TagList;
+import ca.corbett.snotes.model.filter.TagFilter;
+
+import javax.swing.DefaultListModel;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import java.awt.BorderLayout;
+import java.awt.FlowLayout;
+import java.awt.Window;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * Shows a list of all unique non-date tags that are used at least once by any non-scratch Note.
+ * The list offers options for launching a search for selected tags, or double-clicking a single
+ * tag for a single-tag search.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since Snotes 2.2
+ */
+public class TagListDialog extends JDialog {
+
+    private static final Logger log = Logger.getLogger(TagListDialog.class.getName());
+    private final DataManager dataManager;
+    private MessageUtil messageUtil;
+    private final JList<String> tagList;
+
+    /**
+     * Creates a TagListDialog with the given parent and data manager.
+     * The tag list will be retrieved and populated immediately.
+     * The dialog will be modal to the given parent window.
+     *
+     * @param owner the parent window for this dialog
+     * @param dataManager the data manager to retrieve tags from
+     */
+    public TagListDialog(Window owner, DataManager dataManager) {
+        super(owner, "Tag List", ModalityType.APPLICATION_MODAL);
+        this.dataManager = dataManager;
+        setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+        DefaultListModel<String> listModel = new DefaultListModel<>();
+        listModel.addAll(dataManager.getUniqueTags().stream().map(t -> t.getTag()).toList());
+        tagList = new JList<>(listModel);
+        setSize(300, 500);
+        setResizable(true);
+        setLayout(new BorderLayout());
+        add(ScrollUtil.buildScrollPane(tagList), BorderLayout.CENTER);
+        add(buildButtonPanel(), BorderLayout.SOUTH);
+        setLocationRelativeTo(owner);
+
+        // Double-clicking an item in the tag list searches for that item.
+        // Double-clicking on the blank space in the list should do nothing.
+        tagList.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent evt) {
+                if (evt.getClickCount() == 2) {
+                    String selectedTag = tagList.getSelectedValue();
+                    if (selectedTag != null) {
+                        searchSelected();
+                    }
+                }
+            }
+        });
+    }
+
+    private void searchSelected() {
+        int[] selectedIndexes = tagList.getSelectedIndices();
+        if (selectedIndexes.length == 0) {
+            return;
+        }
+        TagList toSearch = new TagList();
+        for (int selectedIndex : selectedIndexes) {
+            toSearch.addTag(tagList.getModel().getElementAt(selectedIndex));
+        }
+        Query query = new Query();
+        query.addFilter(new TagFilter(toSearch.getTags(), TagFilter.FilterType.ALL));
+        List<Note> results = query.execute(dataManager.getNotes());
+        if (results.isEmpty()) {
+            // Each note in our list is guaranteed to be used with at least one note.
+            // But, if the user selected more than one tag, there's no guarantee
+            // that our search in mode ALL will return anything.
+            getMessageUtil().info("There are no notes with the selected tags.");
+            return; // leave this dialog open so they can try again.
+        }
+
+        ReaderFrame readerFrame = new ReaderFrame(results, query);
+        MainWindow.getInstance().addInternalFrame(readerFrame);
+        dispose(); // debatable, but we can assume the user is done with this dialog.
+    }
+
+    private JPanel buildButtonPanel() {
+        JPanel panel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        JButton button = new JButton("Search selected tags");
+        button.addActionListener(e -> searchSelected());
+        panel.add(button);
+        return panel;
+    }
+
+    private MessageUtil getMessageUtil() {
+        if (messageUtil == null) {
+            messageUtil = new MessageUtil(this, log);
+        }
+        return messageUtil;
+    }
+}

--- a/src/main/java/ca/corbett/snotes/ui/TagListDialog.java
+++ b/src/main/java/ca/corbett/snotes/ui/TagListDialog.java
@@ -6,13 +6,17 @@ import ca.corbett.snotes.io.DataManager;
 import ca.corbett.snotes.model.Note;
 import ca.corbett.snotes.model.Query;
 import ca.corbett.snotes.model.TagList;
+import ca.corbett.snotes.model.TagUsage;
 import ca.corbett.snotes.model.filter.TagFilter;
 
-import javax.swing.DefaultListModel;
 import javax.swing.JButton;
 import javax.swing.JDialog;
-import javax.swing.JList;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JTable;
+import javax.swing.ListSelectionModel;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.DefaultTableCellRenderer;
 import java.awt.BorderLayout;
 import java.awt.FlowLayout;
 import java.awt.Window;
@@ -22,9 +26,10 @@ import java.util.List;
 import java.util.logging.Logger;
 
 /**
- * Shows a list of all unique non-date tags that are used at least once by any non-scratch Note.
- * The list offers options for launching a search for selected tags, or double-clicking a single
- * tag for a single-tag search.
+ * Shows a table of all unique non-date tags that are used at least once by any non-scratch Note.
+ * Each row displays the tag name and the number of notes using that tag. The table supports
+ * sorting by clicking column headers. Double-clicking a row or selecting multiple rows and clicking
+ * the search button launches a search for the selected tag(s).
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  * @since Snotes 2.2
@@ -34,7 +39,8 @@ public class TagListDialog extends JDialog {
     private static final Logger log = Logger.getLogger(TagListDialog.class.getName());
     private final DataManager dataManager;
     private MessageUtil messageUtil;
-    private final JList<String> tagList;
+    private final JTable tagTable;
+    private final TagUsageTableModel tableModel;
 
     /**
      * Creates a TagListDialog with the given parent and data manager.
@@ -48,24 +54,28 @@ public class TagListDialog extends JDialog {
         super(owner, "Tag List", ModalityType.APPLICATION_MODAL);
         this.dataManager = dataManager;
         setDefaultCloseOperation(DISPOSE_ON_CLOSE);
-        DefaultListModel<String> listModel = new DefaultListModel<>();
-        listModel.addAll(dataManager.getUniqueTags().stream().map(t -> t.getTag()).toList());
-        tagList = new JList<>(listModel);
+        tableModel = new TagUsageTableModel(dataManager.getUniqueTags());
+        tagTable = new JTable(tableModel);
+        tagTable.setAutoCreateRowSorter(true);
+        tagTable.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
+        tagTable.getColumnModel().getColumn(0).setPreferredWidth(200);
+        tagTable.getColumnModel().getColumn(1).setPreferredWidth(80);
+        tagTable.getColumnModel().getColumn(1).setCellRenderer(new RightAlignedIntegerRenderer());
         setSize(300, 500);
         setResizable(true);
         setLayout(new BorderLayout());
-        add(ScrollUtil.buildScrollPane(tagList), BorderLayout.CENTER);
+        add(ScrollUtil.buildScrollPane(tagTable), BorderLayout.CENTER);
         add(buildButtonPanel(), BorderLayout.SOUTH);
         setLocationRelativeTo(owner);
 
-        // Double-clicking an item in the tag list searches for that item.
-        // Double-clicking on the blank space in the list should do nothing.
-        tagList.addMouseListener(new MouseAdapter() {
+        // Double-clicking a row in the tag table searches for that tag.
+        // Double-clicking on blank space should do nothing.
+        tagTable.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent evt) {
                 if (evt.getClickCount() == 2) {
-                    String selectedTag = tagList.getSelectedValue();
-                    if (selectedTag != null) {
+                    int viewRow = tagTable.getSelectedRow();
+                    if (viewRow >= 0) {
                         searchSelected();
                     }
                 }
@@ -74,19 +84,21 @@ public class TagListDialog extends JDialog {
     }
 
     private void searchSelected() {
-        int[] selectedIndexes = tagList.getSelectedIndices();
-        if (selectedIndexes.length == 0) {
+        int[] selectedViewRows = tagTable.getSelectedRows();
+        if (selectedViewRows.length == 0) {
             return;
         }
         TagList toSearch = new TagList();
-        for (int selectedIndex : selectedIndexes) {
-            toSearch.addTag(tagList.getModel().getElementAt(selectedIndex));
+        for (int viewRow : selectedViewRows) {
+            int modelRow = tagTable.convertRowIndexToModel(viewRow);
+            TagUsage usage = tableModel.getTagUsage(modelRow);
+            toSearch.addTag(usage.tag().getTag());
         }
         Query query = new Query();
         query.addFilter(new TagFilter(toSearch.getTags(), TagFilter.FilterType.ALL));
         List<Note> results = query.execute(dataManager.getNotes());
         if (results.isEmpty()) {
-            // Each note in our list is guaranteed to be used with at least one note.
+            // Each tag in our list is guaranteed to be used with at least one note.
             // But, if the user selected more than one tag, there's no guarantee
             // that our search in mode ALL will return anything.
             getMessageUtil().info("There are no notes with the selected tags.");
@@ -111,5 +123,73 @@ public class TagListDialog extends JDialog {
             messageUtil = new MessageUtil(this, log);
         }
         return messageUtil;
+    }
+
+    // -----------------------------------------------------------------------
+    // Table model
+    // -----------------------------------------------------------------------
+
+    private static final int TAG_COLUMN = 0;
+    private static final int COUNT_COLUMN = 1;
+
+    private class TagUsageTableModel extends AbstractTableModel {
+
+        private final List<TagUsage> data;
+
+        TagUsageTableModel(List<TagUsage> data) {
+            this.data = data;
+        }
+
+        @Override
+        public int getRowCount() {
+            return data.size();
+        }
+
+        @Override
+        public int getColumnCount() {
+            return 2;
+        }
+
+        @Override
+        public String getColumnName(int column) {
+            return switch (column) {
+                case TAG_COLUMN -> "Tag";
+                case COUNT_COLUMN -> "Notes";
+                default -> "";
+            };
+        }
+
+        @Override
+        public Class<?> getColumnClass(int columnIndex) {
+            return switch (columnIndex) {
+                case COUNT_COLUMN -> Integer.class;
+                default -> String.class;
+            };
+        }
+
+        @Override
+        public Object getValueAt(int row, int column) {
+            TagUsage usage = data.get(row);
+            return switch (column) {
+                case TAG_COLUMN -> usage.tag().getTag();
+                case COUNT_COLUMN -> usage.count();
+                default -> null;
+            };
+        }
+
+        TagUsage getTagUsage(int row) {
+            return data.get(row);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Cell renderer
+    // -----------------------------------------------------------------------
+
+    private static class RightAlignedIntegerRenderer extends DefaultTableCellRenderer {
+
+        private RightAlignedIntegerRenderer() {
+            setHorizontalAlignment(JLabel.RIGHT);
+        }
     }
 }

--- a/src/main/java/ca/corbett/snotes/ui/actions/ActionGroup.java
+++ b/src/main/java/ca/corbett/snotes/ui/actions/ActionGroup.java
@@ -96,6 +96,7 @@ public class ActionGroup {
         List<EnhancedAction> queryActions = new ArrayList<>();
 
         queryActions.add(AppConfig.getInstance().getSearchAction());
+        queryActions.add(AppConfig.getInstance().getTagListAction());
 
         // Query CRUD actions:
         queryActions.add(new NewQueryAction());

--- a/src/main/java/ca/corbett/snotes/ui/actions/TagListAction.java
+++ b/src/main/java/ca/corbett/snotes/ui/actions/TagListAction.java
@@ -1,0 +1,25 @@
+package ca.corbett.snotes.ui.actions;
+
+import ca.corbett.extras.EnhancedAction;
+import ca.corbett.snotes.ui.MainWindow;
+import ca.corbett.snotes.ui.TagListDialog;
+
+import java.awt.event.ActionEvent;
+
+/**
+ * An action for launching the TagListDialog.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since Snotes 2.2
+ */
+public class TagListAction extends EnhancedAction {
+    public TagListAction() {
+        super("Tags");
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        TagListDialog dialog = new TagListDialog(MainWindow.getInstance(), MainWindow.getInstance().getDataManager());
+        dialog.setVisible(true);
+    }
+}

--- a/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
@@ -5,6 +5,7 @@ Version 2.2 [TODO release date]
   #92 - add global hotkeys for font size adjustment
   #87 - upgrade to Java 25 / swing-extras 3.0
   #83 - add right-click context menu in editor pane
+  #82 - bring back the tag list from Snotes 1.x
   #79 - fix unit tests on Windows
 
 Version 2.1 [2026-04-29] - Maintenance release

--- a/src/test/java/ca/corbett/snotes/io/DataManagerTest.java
+++ b/src/test/java/ca/corbett/snotes/io/DataManagerTest.java
@@ -2,6 +2,7 @@ package ca.corbett.snotes.io;
 
 import ca.corbett.snotes.model.Note;
 import ca.corbett.snotes.model.Query;
+import ca.corbett.snotes.model.Tag;
 import ca.corbett.snotes.model.Template;
 import ca.corbett.snotes.model.YMDDate;
 import org.junit.jupiter.api.BeforeEach;
@@ -987,5 +988,201 @@ class DataManagerTest {
         assertNotNull(years);
         assertEquals(3, years.size(), "Expected getUniqueYears to return a list with three unique years");
         assertEquals(List.of(2021, 2022, 2023), years, "Expected the unique years to be [2021, 2022, 2023]");
+    }
+
+    // -----------------------------------------------------------------------
+    // getUniqueTags tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    void getUniqueTags_withEmptyDataManager_shouldReturnEmptyList() {
+        // GIVEN a fresh DataManager with no notes:
+        // (dataManager is already empty from @BeforeEach setup)
+
+        // WHEN we call getUniqueTags:
+        List<Tag> tags = dataManager.getUniqueTags();
+
+        // THEN it should return an empty list:
+        assertNotNull(tags);
+        assertTrue(tags.isEmpty(), "Expected getUniqueTags to return an empty list when there are no notes");
+    }
+
+    @Test
+    void getUniqueTags_withNotesHavingNoTags_shouldReturnEmptyList() throws IOException {
+        // GIVEN a DataManager with notes that have no tags (but unique dates to avoid filename collisions):
+        Note note1 = dataManager.newNote();
+        note1.setDate(new YMDDate("2024-01-01"));
+        note1.setText("Tagless note 1");
+        dataManager.save(note1);
+        Note note2 = dataManager.newNote();
+        note2.setDate(new YMDDate("2024-01-02"));
+        note2.setText("Tagless note 2");
+        dataManager.save(note2);
+
+        // WHEN we call getUniqueTags (which only considers non-date tags):
+        List<Tag> tags = dataManager.getUniqueTags();
+
+        // THEN it should return an empty list:
+        assertNotNull(tags);
+        assertTrue(tags.isEmpty(), "Expected getUniqueTags to return an empty list when notes have no tags");
+    }
+
+    @Test
+    void getUniqueTags_withSingleNote_shouldReturnItsTags() throws IOException {
+        // GIVEN a DataManager with a single note that has multiple tags:
+        Note note = dataManager.newNote();
+        note.tag("zebra");
+        note.tag("apple");
+        note.tag("mango");
+        note.setText("A note with multiple tags");
+        dataManager.save(note);
+
+        // WHEN we call getUniqueTags:
+        List<Tag> tags = dataManager.getUniqueTags();
+
+        // THEN it should return the note's tags sorted alphabetically:
+        assertNotNull(tags);
+        assertEquals(3, tags.size(), "Expected getUniqueTags to return three tags");
+        assertEquals("apple", tags.get(0).getTag(), "Expected tags to be sorted alphabetically");
+        assertEquals("mango", tags.get(1).getTag());
+        assertEquals("zebra", tags.get(2).getTag());
+    }
+
+    @Test
+    void getUniqueTags_withMultipleNotes_shouldCombineAllTags() throws IOException {
+        // GIVEN a DataManager with several notes each having different tags:
+        Note note1 = dataManager.newNote();
+        note1.tag("alpha");
+        note1.setText("Note 1");
+        dataManager.save(note1);
+        Note note2 = dataManager.newNote();
+        note2.tag("beta");
+        note2.setText("Note 2");
+        dataManager.save(note2);
+        Note note3 = dataManager.newNote();
+        note3.tag("gamma");
+        note3.setText("Note 3");
+        dataManager.save(note3);
+
+        // WHEN we call getUniqueTags:
+        List<Tag> tags = dataManager.getUniqueTags();
+
+        // THEN it should return all unique tags sorted alphabetically:
+        assertNotNull(tags);
+        assertEquals(3, tags.size(), "Expected getUniqueTags to return three unique tags");
+        assertEquals(List.of("alpha", "beta", "gamma"),
+                     tags.stream().map(Tag::getTag).toList(),
+                     "Expected tags to be sorted alphabetically");
+    }
+
+    @Test
+    void getUniqueTags_withDuplicateTagsAcrossNotes_shouldDeduplicate() throws IOException {
+        // GIVEN a DataManager with several notes sharing some tags:
+        Note note1 = dataManager.newNote();
+        note1.tag("shared");
+        note1.tag("only-in-one");
+        note1.setText("Note 1");
+        dataManager.save(note1);
+        Note note2 = dataManager.newNote();
+        note2.tag("shared");
+        note2.tag("only-in-two");
+        note2.setText("Note 2");
+        dataManager.save(note2);
+        Note note3 = dataManager.newNote();
+        note3.tag("shared");
+        note3.tag("only-in-three");
+        note3.setText("Note 3");
+        dataManager.save(note3);
+
+        // WHEN we call getUniqueTags:
+        List<Tag> tags = dataManager.getUniqueTags();
+
+        // THEN it should deduplicate tags appearing in multiple notes:
+        assertNotNull(tags);
+        assertEquals(4, tags.size(), "Expected four unique tags after deduplication");
+        assertEquals(List.of("only-in-one", "only-in-three", "only-in-two", "shared"),
+                     tags.stream().map(Tag::getTag).toList(),
+                     "Expected deduplicated tags sorted alphabetically");
+    }
+
+    @Test
+    void getUniqueTags_shouldExcludeDateTags() throws IOException {
+        // GIVEN a DataManager with dated and undated notes:
+        Note note1 = dataManager.newNote();
+        note1.setDate(new YMDDate("2024-06-15"));
+        note1.tag("alpha");
+        note1.setText("Dated note");
+        dataManager.save(note1);
+        Note note2 = dataManager.newNote();
+        note2.tag("beta");
+        note2.setText("Undated note");
+        dataManager.save(note2);
+
+        // WHEN we call getUniqueTags:
+        List<Tag> tags = dataManager.getUniqueTags();
+
+        // THEN date tags should be excluded but regular tags included:
+        assertNotNull(tags);
+        assertEquals(2, tags.size(), "Expected two non-date tags");
+        assertEquals("alpha", tags.get(0).getTag());
+        assertEquals("beta", tags.get(1).getTag());
+        // Verify no tag starts with a date pattern (yyyy-MM-dd)
+        for (Tag tag : tags) {
+            assertFalse(tag.getTag().matches("\\d{4}-\\d{2}-\\d{2}"),
+                        "Expected no date tags in the result");
+        }
+    }
+
+    @Test
+    void getUniqueTags_shouldExcludeScratchNotes() throws IOException {
+        // GIVEN a DataManager with a promoted note and a scratch note:
+        Note realNote = dataManager.newNote();
+        realNote.tag("real-tag");
+        realNote.setText("Real note content");
+        dataManager.save(realNote);
+
+        Note scratchNote = dataManager.newNote();
+        scratchNote.tag("scratch-tag");
+        scratchNote.tag("real-tag");
+        scratchNote.setText("Scratch note content");
+
+        // WHEN we call getUniqueTags (scratch notes should not be included):
+        List<Tag> tags = dataManager.getUniqueTags();
+
+        // THEN only tags from real notes should appear:
+        assertNotNull(tags);
+        assertEquals(1, tags.size(), "Expected only tags from real notes");
+        assertEquals("real-tag", tags.get(0).getTag(),
+                     "Expected only the real note's tag");
+    }
+
+    @Test
+    void getUniqueTags_withMixedDatedAndUndatedNotes_shouldReturnAllNonDateTags() throws IOException {
+        // GIVEN a DataManager with a mix of dated and undated notes:
+        Note note1 = dataManager.newNote();
+        note1.setDate(new YMDDate("2024-01-01"));
+        note1.tag("alpha");
+        note1.setText("Dated note");
+        dataManager.save(note1);
+        Note note2 = dataManager.newNote();
+        note2.tag("beta");
+        note2.setText("Undated note");
+        dataManager.save(note2);
+        Note note3 = dataManager.newNote();
+        note3.setDate(new YMDDate("2024-07-15"));
+        note3.tag("alpha");
+        note3.tag("gamma");
+        note3.setText("Another dated note");
+        dataManager.save(note3);
+
+        // WHEN we call getUniqueTags:
+        List<Tag> tags = dataManager.getUniqueTags();
+
+        // THEN it should return all unique non-date tags, sorted and deduplicated:
+        assertNotNull(tags);
+        assertEquals(3, tags.size(), "Expected three unique non-date tags");
+        assertEquals(List.of("alpha", "beta", "gamma"),
+                     tags.stream().map(Tag::getTag).toList(),
+                     "Expected deduplicated non-date tags sorted alphabetically");
     }
 }

--- a/src/test/java/ca/corbett/snotes/io/DataManagerTest.java
+++ b/src/test/java/ca/corbett/snotes/io/DataManagerTest.java
@@ -2,7 +2,7 @@ package ca.corbett.snotes.io;
 
 import ca.corbett.snotes.model.Note;
 import ca.corbett.snotes.model.Query;
-import ca.corbett.snotes.model.Tag;
+import ca.corbett.snotes.model.TagUsage;
 import ca.corbett.snotes.model.Template;
 import ca.corbett.snotes.model.YMDDate;
 import org.junit.jupiter.api.BeforeEach;
@@ -1000,11 +1000,11 @@ class DataManagerTest {
         // (dataManager is already empty from @BeforeEach setup)
 
         // WHEN we call getUniqueTags:
-        List<Tag> tags = dataManager.getUniqueTags();
+        List<TagUsage> usages = dataManager.getUniqueTags();
 
         // THEN it should return an empty list:
-        assertNotNull(tags);
-        assertTrue(tags.isEmpty(), "Expected getUniqueTags to return an empty list when there are no notes");
+        assertNotNull(usages);
+        assertTrue(usages.isEmpty(), "Expected getUniqueTags to return an empty list when there are no notes");
     }
 
     @Test
@@ -1020,11 +1020,11 @@ class DataManagerTest {
         dataManager.save(note2);
 
         // WHEN we call getUniqueTags (which only considers non-date tags):
-        List<Tag> tags = dataManager.getUniqueTags();
+        List<TagUsage> usages = dataManager.getUniqueTags();
 
         // THEN it should return an empty list:
-        assertNotNull(tags);
-        assertTrue(tags.isEmpty(), "Expected getUniqueTags to return an empty list when notes have no tags");
+        assertNotNull(usages);
+        assertTrue(usages.isEmpty(), "Expected getUniqueTags to return an empty list when notes have no tags");
     }
 
     @Test
@@ -1038,14 +1038,17 @@ class DataManagerTest {
         dataManager.save(note);
 
         // WHEN we call getUniqueTags:
-        List<Tag> tags = dataManager.getUniqueTags();
+        List<TagUsage> usages = dataManager.getUniqueTags();
 
-        // THEN it should return the note's tags sorted alphabetically:
-        assertNotNull(tags);
-        assertEquals(3, tags.size(), "Expected getUniqueTags to return three tags");
-        assertEquals("apple", tags.get(0).getTag(), "Expected tags to be sorted alphabetically");
-        assertEquals("mango", tags.get(1).getTag());
-        assertEquals("zebra", tags.get(2).getTag());
+        // THEN it should return the note's tags sorted alphabetically, each with count 1:
+        assertNotNull(usages);
+        assertEquals(3, usages.size(), "Expected getUniqueTags to return three tags");
+        assertEquals("apple", usages.get(0).tag().getTag(), "Expected tags to be sorted alphabetically");
+        assertEquals(1, usages.get(0).count(), "Expected count of 1 for single-note tag");
+        assertEquals("mango", usages.get(1).tag().getTag());
+        assertEquals(1, usages.get(1).count());
+        assertEquals("zebra", usages.get(2).tag().getTag());
+        assertEquals(1, usages.get(2).count());
     }
 
     @Test
@@ -1065,14 +1068,17 @@ class DataManagerTest {
         dataManager.save(note3);
 
         // WHEN we call getUniqueTags:
-        List<Tag> tags = dataManager.getUniqueTags();
+        List<TagUsage> usages = dataManager.getUniqueTags();
 
-        // THEN it should return all unique tags sorted alphabetically:
-        assertNotNull(tags);
-        assertEquals(3, tags.size(), "Expected getUniqueTags to return three unique tags");
+        // THEN it should return all unique tags sorted alphabetically, each with count 1:
+        assertNotNull(usages);
+        assertEquals(3, usages.size(), "Expected getUniqueTags to return three unique tags");
         assertEquals(List.of("alpha", "beta", "gamma"),
-                     tags.stream().map(Tag::getTag).toList(),
+                     usages.stream().map(u -> u.tag().getTag()).toList(),
                      "Expected tags to be sorted alphabetically");
+        for (TagUsage usage : usages) {
+            assertEquals(1, usage.count(), "Expected each tag to have a count of 1");
+        }
     }
 
     @Test
@@ -1095,14 +1101,18 @@ class DataManagerTest {
         dataManager.save(note3);
 
         // WHEN we call getUniqueTags:
-        List<Tag> tags = dataManager.getUniqueTags();
+        List<TagUsage> usages = dataManager.getUniqueTags();
 
-        // THEN it should deduplicate tags appearing in multiple notes:
-        assertNotNull(tags);
-        assertEquals(4, tags.size(), "Expected four unique tags after deduplication");
+        // THEN it should deduplicate tags appearing in multiple notes and report correct counts:
+        assertNotNull(usages);
+        assertEquals(4, usages.size(), "Expected four unique tags after deduplication");
         assertEquals(List.of("only-in-one", "only-in-three", "only-in-two", "shared"),
-                     tags.stream().map(Tag::getTag).toList(),
+                     usages.stream().map(u -> u.tag().getTag()).toList(),
                      "Expected deduplicated tags sorted alphabetically");
+        assertEquals(1, usages.get(0).count(), "only-in-one is used by 1 note");
+        assertEquals(1, usages.get(1).count(), "only-in-three is used by 1 note");
+        assertEquals(1, usages.get(2).count(), "only-in-two is used by 1 note");
+        assertEquals(3, usages.get(3).count(), "shared is used by 3 notes");
     }
 
     @Test
@@ -1119,16 +1129,16 @@ class DataManagerTest {
         dataManager.save(note2);
 
         // WHEN we call getUniqueTags:
-        List<Tag> tags = dataManager.getUniqueTags();
+        List<TagUsage> usages = dataManager.getUniqueTags();
 
         // THEN date tags should be excluded but regular tags included:
-        assertNotNull(tags);
-        assertEquals(2, tags.size(), "Expected two non-date tags");
-        assertEquals("alpha", tags.get(0).getTag());
-        assertEquals("beta", tags.get(1).getTag());
+        assertNotNull(usages);
+        assertEquals(2, usages.size(), "Expected two non-date tags");
+        assertEquals("alpha", usages.get(0).tag().getTag());
+        assertEquals("beta", usages.get(1).tag().getTag());
         // Verify no tag starts with a date pattern (yyyy-MM-dd)
-        for (Tag tag : tags) {
-            assertFalse(tag.getTag().matches("\\d{4}-\\d{2}-\\d{2}"),
+        for (TagUsage usage : usages) {
+            assertFalse(usage.tag().getTag().matches("\\d{4}-\\d{2}-\\d{2}"),
                         "Expected no date tags in the result");
         }
     }
@@ -1147,13 +1157,14 @@ class DataManagerTest {
         scratchNote.setText("Scratch note content");
 
         // WHEN we call getUniqueTags (scratch notes should not be included):
-        List<Tag> tags = dataManager.getUniqueTags();
+        List<TagUsage> usages = dataManager.getUniqueTags();
 
         // THEN only tags from real notes should appear:
-        assertNotNull(tags);
-        assertEquals(1, tags.size(), "Expected only tags from real notes");
-        assertEquals("real-tag", tags.get(0).getTag(),
+        assertNotNull(usages);
+        assertEquals(1, usages.size(), "Expected only tags from real notes");
+        assertEquals("real-tag", usages.get(0).tag().getTag(),
                      "Expected only the real note's tag");
+        assertEquals(1, usages.get(0).count(), "Expected count of 1 for the real note's tag");
     }
 
     @Test
@@ -1176,13 +1187,16 @@ class DataManagerTest {
         dataManager.save(note3);
 
         // WHEN we call getUniqueTags:
-        List<Tag> tags = dataManager.getUniqueTags();
+        List<TagUsage> usages = dataManager.getUniqueTags();
 
-        // THEN it should return all unique non-date tags, sorted and deduplicated:
-        assertNotNull(tags);
-        assertEquals(3, tags.size(), "Expected three unique non-date tags");
+        // THEN it should return all unique non-date tags, sorted and deduplicated, with correct counts:
+        assertNotNull(usages);
+        assertEquals(3, usages.size(), "Expected three unique non-date tags");
         assertEquals(List.of("alpha", "beta", "gamma"),
-                     tags.stream().map(Tag::getTag).toList(),
+                     usages.stream().map(u -> u.tag().getTag()).toList(),
                      "Expected deduplicated non-date tags sorted alphabetically");
+        assertEquals(2, usages.get(0).count(), "alpha is used by 2 notes");
+        assertEquals(1, usages.get(1).count(), "beta is used by 1 note");
+        assertEquals(1, usages.get(2).count(), "gamma is used by 1 note");
     }
 }


### PR DESCRIPTION
This PR addresses issue #82 by introducing a `TagListDialog` that the user can summon to view a flat, ordered, deduplicated list of all non-date tags used by at least one non-scratch note. Double-clicking a tag in the list will automatically dismiss the tag list dialog and open a ReaderFrame with all notes that use that tag (if there are any). Alternatively, users can multi-select rows in the list and hit the search button on the bottom to do a search (filter mode ALL) for the selected tags.

A count of how many notes reference that tag is also displayed. Clicking either column header allows the user to sort or reverse-sort by that column's value. This allows quickly inspecting the list to find the most and least popular tags.

Unit tests included for the new `getUniqueTags()` method in `DataManager`.