### PR TITLE
Issue #86 - smarten up the LogConsole a bit

### DIFF
--- a/src/main/java/ca/corbett/snotes/extensions/SnotesExtension.java
+++ b/src/main/java/ca/corbett/snotes/extensions/SnotesExtension.java
@@ -2,6 +2,7 @@ package ca.corbett.snotes.extensions;
 
 import ca.corbett.extensions.AppExtension;
 import ca.corbett.extras.EnhancedAction;
+import ca.corbett.extras.logging.LogConsoleStyle;
 import ca.corbett.snotes.ui.actions.ActionGroup;
 
 import java.util.List;
@@ -40,6 +41,16 @@ public abstract class SnotesExtension extends AppExtension {
      * </p>
      */
     public List<EnhancedAction> getExtraActions(String actionGroupName) {
+        return List.of();
+    }
+
+    /**
+     * Extensions can return a list of LogConsoleStyles to be applied to the Snotes
+     * LogConsole theme.
+     *
+     * @return A List of LogConsoleStyle objects, or null/empty if nothing to contribute.
+     */
+    public List<LogConsoleStyle> getLogConsoleStyles() {
         return List.of();
     }
 }

--- a/src/main/java/ca/corbett/snotes/extensions/SnotesExtensionManager.java
+++ b/src/main/java/ca/corbett/snotes/extensions/SnotesExtensionManager.java
@@ -2,6 +2,7 @@ package ca.corbett.snotes.extensions;
 
 import ca.corbett.extensions.ExtensionManager;
 import ca.corbett.extras.EnhancedAction;
+import ca.corbett.extras.logging.LogConsoleStyle;
 import ca.corbett.extras.properties.KeyStrokeProperty;
 import ca.corbett.snotes.Version;
 import ca.corbett.snotes.extensions.builtin.TestExtension;
@@ -124,5 +125,22 @@ public class SnotesExtensionManager extends ExtensionManager<SnotesExtension> {
         // Deliberately not documented anywhere, but -Dsnotes.enableTestExtension will enable our test extension
         String testExtProp = System.getProperty("snotes.enableTestExtension", null);
         return Version.getAboutInfo().applicationVersion.contains("SNAPSHOT") || testExtProp != null;
+    }
+
+    /**
+     * Gives all extensions a chance to register custom LogConsoleStyle objects for use
+     * with the Snotes theme in our LogConsole.
+     *
+     * @return A List of LogConsoleStyle instances, may be empty.
+     */
+    public List<LogConsoleStyle> getLogConsoleStyles() {
+        List<LogConsoleStyle> list = new ArrayList<>();
+        for (SnotesExtension extension : getEnabledLoadedExtensions()) {
+            List<LogConsoleStyle> toAdd = extension.getLogConsoleStyles();
+            if (toAdd != null) {
+                list.addAll(toAdd);
+            }
+        }
+        return list;
     }
 }

--- a/src/main/java/ca/corbett/snotes/io/DataManager.java
+++ b/src/main/java/ca/corbett/snotes/io/DataManager.java
@@ -472,6 +472,7 @@ public class DataManager {
 
         // Now save this Template to its new location. This will update its source file and mark it clean.
         SnotesIO.saveTemplate(template, targetFile);
+        log.info("Saved template: " + targetFile.getName());
 
         // If this Template wasn't already in our cache, add it now:
         if (!templates.contains(template)) {
@@ -518,6 +519,7 @@ public class DataManager {
 
         // Now save this Query to its new location. This will update the Query's source file and mark it clean.
         SnotesIO.saveQuery(query, targetFile);
+        log.info("Saved query: " + targetFile.getName());
 
         // If this Query wasn't already in our cache, add it now:
         if (!queries.contains(query)) {

--- a/src/main/java/ca/corbett/snotes/ui/MainWindow.java
+++ b/src/main/java/ca/corbett/snotes/ui/MainWindow.java
@@ -7,6 +7,8 @@ import ca.corbett.extras.actionpanel.ActionPanel;
 import ca.corbett.extras.image.animation.BlurLayerUI;
 import ca.corbett.extras.io.KeyStrokeManager;
 import ca.corbett.extras.logging.LogConsole;
+import ca.corbett.extras.logging.LogConsoleStyle;
+import ca.corbett.extras.logging.LogConsoleTheme;
 import ca.corbett.extras.properties.KeyStrokeProperty;
 import ca.corbett.snotes.AppConfig;
 import ca.corbett.snotes.Main;
@@ -30,6 +32,7 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.beans.PropertyVetoException;
 import java.io.IOException;
+import java.util.List;
 import java.util.logging.Logger;
 
 /**
@@ -78,6 +81,7 @@ public class MainWindow extends JFrame implements UIReloadable {
         dataManager.addNoteDeletionListener(this::noteDeleted);
         keyStrokeManager = new KeyStrokeManager(this);
         actionPanelManager = new ActionPanelManager();
+        configureLogConsole();
         blurLayer = new BlurLayerUI();
         blurLayer.setBlurOverlayColor(Color.LIGHT_GRAY);
         blurLayer.setOverlayTextColor(Color.WHITE);
@@ -354,6 +358,43 @@ public class MainWindow extends JFrame implements UIReloadable {
             SingleInstanceManager.getInstance().release();
         }
     }
+
+    /**
+     * Invoked internally to set up our custom LogConsole theme and activate it by default.
+     */
+    private void configureLogConsole() {
+        // We'll start by cloning the green-on-black matrix theme and customize it a bit:
+        LogConsoleTheme theme = LogConsoleTheme.createMatrixStyledTheme();
+
+        // Set up custom log styles for our main actions:
+        theme.setStyle("saveScratchNote", createStyle("Saved scratch note:", true, Color.CYAN, false));
+        theme.setStyle("saveNote", createStyle("Saved note:", true, Color.MAGENTA, false));
+        theme.setStyle("deleteScratchNote", createStyle("Deleted scratch note:", true, Color.ORANGE, false));
+        theme.setStyle("deleteNote", createStyle("Deleted note:", true, Color.ORANGE, false));
+        theme.setStyle("saveTemplate", createStyle("Saved template:", true, Color.PINK, false));
+        theme.setStyle("saveQuery", createStyle("Saved query:", true, Color.PINK, false));
+
+        // Add any provided by extensions:
+        List<LogConsoleStyle> extensionStyles = SnotesExtensionManager.getInstance().getLogConsoleStyles();
+        int index = 1; // this is dumb, but we need a unique identifier for each style
+        for (LogConsoleStyle extensionStyle : extensionStyles) {
+            theme.setStyle("extensionStyle" + index, extensionStyle);
+            index++;
+        }
+
+        // Register our custom theme.
+        // This will overwrite any previous theme of this name, so it's safe to call this repeatedly.
+        LogConsole.getInstance().registerTheme("Snotes", theme, true);
+    }
+
+    private static LogConsoleStyle createStyle(String token, boolean isCaseSensitive, Color fontColor, boolean isBold) {
+        LogConsoleStyle style = new LogConsoleStyle();
+        style.setLogToken(token, isCaseSensitive);
+        style.setFontColor(fontColor);
+        style.setIsBold(isBold);
+        return style;
+    }
+
 
     /**
      * If "remember window size and position" is enabled, restores the

--- a/src/main/java/ca/corbett/snotes/ui/MainWindow.java
+++ b/src/main/java/ca/corbett/snotes/ui/MainWindow.java
@@ -81,7 +81,6 @@ public class MainWindow extends JFrame implements UIReloadable {
         dataManager.addNoteDeletionListener(this::noteDeleted);
         keyStrokeManager = new KeyStrokeManager(this);
         actionPanelManager = new ActionPanelManager();
-        configureLogConsole();
         blurLayer = new BlurLayerUI();
         blurLayer.setBlurOverlayColor(Color.LIGHT_GRAY);
         blurLayer.setOverlayTextColor(Color.WHITE);
@@ -90,6 +89,7 @@ public class MainWindow extends JFrame implements UIReloadable {
         initComponents();
         addWindowListener(new WindowCloseHandler());
         cleanupComplete = false;
+        SwingUtilities.invokeLater(this::configureLogConsole); // this touches UI components, so do it on the EDT
     }
 
     public static MainWindow getInstance() {

--- a/src/main/java/ca/corbett/snotes/ui/actions/LogConsoleAction.java
+++ b/src/main/java/ca/corbett/snotes/ui/actions/LogConsoleAction.java
@@ -2,6 +2,7 @@ package ca.corbett.snotes.ui.actions;
 
 import ca.corbett.extras.EnhancedAction;
 import ca.corbett.extras.logging.LogConsole;
+import ca.corbett.snotes.ui.MainWindow;
 
 import java.awt.event.ActionEvent;
 
@@ -13,12 +14,23 @@ import java.awt.event.ActionEvent;
  */
 public class LogConsoleAction extends EnhancedAction {
 
+    private static boolean positionAdjusted = false;
+
     public LogConsoleAction() {
         super("Show Log Console");
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
+        // The first time LogConsole is shown, we'll position it over the MainWindow.
+        // But LogConsole is a singleton hide-when-closed window, so if the user adjusts
+        // its position manually after bringing it up, and then closes it, we don't want
+        // to mess with it again.
+        if (!positionAdjusted) {
+            LogConsole.getInstance().setLocationRelativeTo(MainWindow.getInstance());
+            positionAdjusted = true;
+        }
+
         LogConsole.getInstance().setVisible(true);
     }
 }

--- a/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
@@ -4,6 +4,7 @@ Author: Steve Corbett
 Version 2.2 [TODO release date]
   #92 - add global hotkeys for font size adjustment
   #87 - upgrade to Java 25 / swing-extras 3.0
+  #86 - smarten up the LogConsole a bit
   #83 - add right-click context menu in editor pane
   #82 - bring back the tag list from Snotes 1.x
   #79 - fix unit tests on Windows


### PR DESCRIPTION
This PR addresses issue #86 by smartening up our use of the `LogConsole` utility:

- better initial window placement
- addition of a custom "Snotes" theme (based on the Matrix theme)
- ability for extensions to contribute to our custom theme (optional)
- automatic activation of the custom theme
