### PR TITLE
Issue #84 - remap about shortcut so it doesn't conflict with select all

### DIFF
--- a/src/main/java/ca/corbett/snotes/AppConfig.java
+++ b/src/main/java/ca/corbett/snotes/AppConfig.java
@@ -617,7 +617,7 @@ public class AppConfig extends AppProperties<SnotesExtension> {
         List<AbstractProperty> props = new ArrayList<>();
 
         props.add(new KeyStrokeProperty(KEY_ABOUT, "About dialog:",
-                                        KeyStrokeManager.parseKeyStroke("Ctrl+A"), aboutAction)
+                                        KeyStrokeManager.parseKeyStroke("F1"), aboutAction)
                       .setAllowBlank(true));
         props.add(new KeyStrokeProperty(KEY_SAVE, "Save:",
                                         KeyStrokeManager.parseKeyStroke("Ctrl+S"), saveAction)

--- a/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
@@ -5,6 +5,7 @@ Version 2.2 [TODO release date]
   #92 - add global hotkeys for font size adjustment
   #87 - upgrade to Java 25 / swing-extras 3.0
   #86 - smarten up the LogConsole a bit
+  #84 - remap "About" shortcut to not conflict with select all
   #83 - add right-click context menu in editor pane
   #82 - bring back the tag list from Snotes 1.x
   #79 - fix unit tests on Windows


### PR DESCRIPTION
This PR addresses issue #84 by changing the default mapping for the About dialog so that it doesn't conflict with the "select all" shortcut in our `JTextPane` instances. The new default is `F1`. 

This change only affects new users. Existing installs will use the value from the application preferences file and will ignore the default. Existing users must manually remap the shortcut to avoid the conflict (which was the suggested workaround on the bug ticket).
