### PR TITLE
Issue #91 add save-and-stay-open button in WriterFrame

### DIFF
--- a/src/main/java/ca/corbett/snotes/ui/WriterFrame.java
+++ b/src/main/java/ca/corbett/snotes/ui/WriterFrame.java
@@ -454,7 +454,7 @@ public class WriterFrame extends JInternalFrame implements UIReloadable {
         JPanel panel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
         panel.setBorder(BorderFactory.createRaisedBevelBorder());
         JButton btn = new JButton("Save");
-        btn.addActionListener(e -> saveInternal(false));
+        btn.addActionListener(e -> save());
         btn.setPreferredSize(new Dimension(140, 24));
         panel.add(btn);
         btn = new JButton("Save and close");

--- a/src/main/java/ca/corbett/snotes/ui/WriterFrame.java
+++ b/src/main/java/ca/corbett/snotes/ui/WriterFrame.java
@@ -454,8 +454,12 @@ public class WriterFrame extends JInternalFrame implements UIReloadable {
         JPanel panel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
         panel.setBorder(BorderFactory.createRaisedBevelBorder());
         JButton btn = new JButton("Save");
+        btn.addActionListener(e -> saveInternal(false));
+        btn.setPreferredSize(new Dimension(140, 24));
+        panel.add(btn);
+        btn = new JButton("Save and close");
         btn.addActionListener(e -> saveInternal(true));
-        btn.setPreferredSize(new Dimension(110, 24));
+        btn.setPreferredSize(new Dimension(140, 24));
         panel.add(btn);
         return panel;
     }

--- a/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
@@ -3,6 +3,7 @@ Author: Steve Corbett
 
 Version 2.2 [TODO release date]
   #92 - add global hotkeys for font size adjustment
+  #91 - better division of "save and close" and "save and stay open"
   #87 - upgrade to Java 25 / swing-extras 3.0
   #86 - smarten up the LogConsole a bit
   #85 - add reader/writer frame text search


### PR DESCRIPTION
This PR addresses issue #91 by adding a save-and-stay-open button in `WriterFrame`. This was technically already possible with the application global `ctrl+s` keyboard shortcut, but that feature was not well-advertised, so it wasn't necessarily obvious to users that they could do it. 

Renamed the existing "Save" button to "Save and close" to better reflect what it does. Added a new "Save" button that will execute a save without closing the writer frame.

Scratch note handling: the new "save" button does NOT promote a scratch note to a real note! This is consistent with the existing `ctrl+s` save approach, and also with the writer frame's auto-save timer. Hitting "save" simply performs a scratch save on the scratch note. Hitting "Save and close" on a scratch note will perform the note promotion.
