### PR TITLE
Issue #103 - WriterFrame: fix focux bug when closing text find controls

### DIFF
--- a/src/main/java/ca/corbett/snotes/ui/WriterFrame.java
+++ b/src/main/java/ca/corbett/snotes/ui/WriterFrame.java
@@ -448,6 +448,7 @@ public class WriterFrame extends JInternalFrame implements UIReloadable {
         textFindPanel.setVisible(false);
         textWrapperPanel.revalidate();
         textWrapperPanel.repaint();
+        textPane.requestFocusInWindow();
     }
 
     private JPanel buildButtonPanel() {

--- a/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/snotes/ReleaseNotes.txt
@@ -2,6 +2,7 @@ Snotes Release Notes
 Author: Steve Corbett
 
 Version 2.2 [TODO release date]
+  #103 - WriterFrame: fix focus bug when cancelling text find
   #92 - add global hotkeys for font size adjustment
   #91 - better division of "save and close" and "save and stay open"
   #87 - upgrade to Java 25 / swing-extras 3.0


### PR DESCRIPTION
This PR addresses issue #103 by fixing a minor focus issue in WriterFrame when closing the text find controls. We now ensure that the focus goes back to the edit pane when the text find controls close.